### PR TITLE
Lang.ja-JP.xaml　Iceborne ver

### DIFF
--- a/MHW-Shop-Editor/Lang.ja-JP.xaml
+++ b/MHW-Shop-Editor/Lang.ja-JP.xaml
@@ -1,0 +1,2767 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:MHWShopEditor"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib"
+                    xmlns:handlers="clr-namespace:MHWShopEditor.Handlers">
+
+
+    <!--application-->
+    <system:String x:Key="title">MHW Shop Editor</system:String>
+    <system:String x:Key="file">ファイル</system:String>
+    <system:String x:Key="open">開く</system:String>
+    <system:String x:Key="save">保存</system:String>
+    <system:String x:Key="lang">言語</system:String>
+    <system:String x:Key="default">デフォルト</system:String>
+    <system:String x:Key="gems">装飾品</system:String>
+    <system:String x:Key="clear">全クリア</system:String>
+    <system:String x:Key="consumables">消耗品</system:String>
+    <system:String x:Key="lr_mats">下位素材</system:String>
+    <system:String x:Key="hr_mats">上位素材</system:String>
+    <system:String x:Key="settings">設定</system:String>
+    <system:String x:Key="insertTop">先頭に挿入</system:String>
+    <system:String x:Key="insertBottom">末尾に挿入</system:String>
+    <system:String x:Key="count">アイテム数:</system:String>
+    <system:String x:Key="results">結果:</system:String>
+
+
+    <!--itemlist-->
+    <x:Array Type="handles:Item" x:Key="itemsList" >
+        <handlers:Item Key="item0001" Value="回復薬"/>
+        <handlers:Item Key="item0002" Value="回復薬グレート"/>
+        <handlers:Item Key="item0003" Value="秘薬"/>
+        <handlers:Item Key="item0004" Value="いにしえの秘薬"/>
+        <handlers:Item Key="item0005" Value="解毒薬"/>
+        <handlers:Item Key="item0006" Value="漢方薬"/>
+        <handlers:Item Key="item0007" Value="ウチケシの実"/>
+        <handlers:Item Key="item0008" Value="元気ドリンコ"/>
+        <handlers:Item Key="item0009" Value="携帯食料"/>
+        <handlers:Item Key="item000A" Value="生焼け肉"/>
+        <handlers:Item Key="item000B" Value="こんがり肉"/>
+        <handlers:Item Key="item000C" Value="コゲ肉"/>
+        <handlers:Item Key="item000D" Value="クーラードリンク"/>
+        <handlers:Item Key="item000E" Value="栄養剤"/>
+        <handlers:Item Key="item000F" Value="栄養剤グレート"/>
+        <handlers:Item Key="item0010" Value="活力剤"/>
+        <handlers:Item Key="item0011" Value="アステラジャーキー"/>
+        <handlers:Item Key="item0012" Value="強走薬"/>
+        <handlers:Item Key="item0013" Value="Mega Dash Juice"/>
+        <handlers:Item Key="item0014" Value="怪力の種"/>
+        <handlers:Item Key="item0015" Value="鬼人薬"/>
+        <handlers:Item Key="item0016" Value="鬼人薬グレート"/>
+        <handlers:Item Key="item0017" Value="怪力の丸薬"/>
+        <handlers:Item Key="item0018" Value="忍耐の種"/>
+        <handlers:Item Key="item0019" Value="硬化薬"/>
+        <handlers:Item Key="item001A" Value="硬化薬グレート"/>
+        <handlers:Item Key="item001B" Value="忍耐の丸薬"/>
+        <handlers:Item Key="item001C" Value="生命の粉塵"/>
+        <handlers:Item Key="item001D" Value="漢方の粉塵"/>
+        <handlers:Item Key="item001E" Value="鬼人の粉塵"/>
+        <handlers:Item Key="item001F" Value="硬化の粉塵"/>
+        <handlers:Item Key="item0020" Value="ハチミツ"/>
+        <handlers:Item Key="item0021" Value="薬草"/>
+        <handlers:Item Key="item0022" Value="げどく草"/>
+        <handlers:Item Key="item0023" Value="火薬草"/>
+        <handlers:Item Key="item0024" Value="流水草"/>
+        <handlers:Item Key="item0025" Value="霜ふり草"/>
+        <handlers:Item Key="item0026" Value="ネムリ草"/>
+        <handlers:Item Key="item0027" Value="ツタの葉"/>
+        <handlers:Item Key="item0028" Value="ケムリの実"/>
+        <handlers:Item Key="item0029" Value="龍殺しの実"/>
+        <handlers:Item Key="item002A" Value="アオキノコ"/>
+        <handlers:Item Key="item002B" Value="マンドラゴラ"/>
+        <handlers:Item Key="item002C" Value="ニトロダケ"/>
+        <handlers:Item Key="item002D" Value="鬼ニトロダケ"/>
+        <handlers:Item Key="item002E" Value="マヒダケ"/>
+        <handlers:Item Key="item002F" Value="毒テングダケ"/>
+        <handlers:Item Key="item0030" Value="ドキドキノコ"/>
+        <handlers:Item Key="item0031" Value="にが虫"/>
+        <handlers:Item Key="item0032" Value="光蟲"/>
+        <handlers:Item Key="item0033" Value="不死虫"/>
+        <handlers:Item Key="item0034" Value="雷光虫"/>
+        <handlers:Item Key="item0035" Value="イレグイコガネ"/>
+        <handlers:Item Key="item0036" Value="ケルビの角"/>
+        <handlers:Item Key="item0037" Value="狂走エキス"/>
+        <handlers:Item Key="item0038" Value="滋養エキス"/>
+        <handlers:Item Key="item0039" Value="鳴き袋"/>
+        <handlers:Item Key="item003A" Value="増強剤"/>
+        <handlers:Item Key="item003B" Value="捕獲用麻酔玉"/>
+        <handlers:Item Key="item003C" Value="スリンガー閃光弾"/>
+        <handlers:Item Key="item003D" Value="スリンガー音爆弾"/>
+        <handlers:Item Key="item003E" Value="けむり玉"/>
+        <handlers:Item Key="item003F" Value="毒けむり玉"/>
+        <handlers:Item Key="item0040" Value="モドリ玉"/>
+        <handlers:Item Key="item0041" Value="生肉"/>
+        <handlers:Item Key="item0042" Value="毒生肉"/>
+        <handlers:Item Key="item0043" Value="シビレ生肉"/>
+        <handlers:Item Key="item0044" Value="眠り生肉"/>
+        <handlers:Item Key="item0045" Value="爆薬"/>
+        <handlers:Item Key="item0046" Value="小タル"/>
+        <handlers:Item Key="item0047" Value="小タル爆弾"/>
+        <handlers:Item Key="item0048" Value="打上げタル爆弾"/>
+        <handlers:Item Key="item0049" Value="打上げタル爆弾Ｇ"/>
+        <handlers:Item Key="item004A" Value="大タル"/>
+        <handlers:Item Key="item004B" Value="大タル爆弾"/>
+        <handlers:Item Key="item004C" Value="大タル爆弾Ｇ"/>
+        <handlers:Item Key="item004D" Value="クモの巣"/>
+        <handlers:Item Key="item004E" Value="ネット"/>
+        <handlers:Item Key="item004F" Value="トラップツール"/>
+        <handlers:Item Key="item0050" Value="落とし穴"/>
+        <handlers:Item Key="item0051" Value="シビレ罠"/>
+        <handlers:Item Key="item0052" Value="ころがされたフン"/>
+        <handlers:Item Key="item0053" Value="モンスターのフン"/>
+        <handlers:Item Key="item0054" Value="スリンガーこやし弾"/>
+        <handlers:Item Key="item0055" Value="アロワナダンゴ"/>
+        <handlers:Item Key="item0056" Value="デメキンダンゴ"/>
+        <handlers:Item Key="item0057" Value="黄金ダンゴ"/>
+        <handlers:Item Key="item0058" Value="ブーメラン"/>
+        <handlers:Item Key="item0059" Value="双眼鏡"/>
+        <handlers:Item Key="item005A" Value="力の護符"/>
+        <handlers:Item Key="item005B" Value="力の爪"/>
+        <handlers:Item Key="item005C" Value="守りの護符"/>
+        <handlers:Item Key="item005D" Value="守りの爪"/>
+        <handlers:Item Key="item005E" Value="ハリの実"/>
+        <handlers:Item Key="item005F" Value="バクレツの実"/>
+        <handlers:Item Key="item0060" Value="リュウゲキの実"/>
+        <handlers:Item Key="item0061" Value="ザンレツの実"/>
+        <handlers:Item Key="item0062" Value="ツラヌキの実"/>
+        <handlers:Item Key="item0063" Value="カクサンの実"/>
+        <handlers:Item Key="item0064" Value="チャッカの実"/>
+        <handlers:Item Key="item0065" Value="ハッカの実"/>
+        <handlers:Item Key="item0066" Value="LV2 火薬粉"/>
+        <handlers:Item Key="item0067" Value="LV3 火薬粉"/>
+        <handlers:Item Key="item0068" Value="キレアジのヒレ"/>
+        <handlers:Item Key="item0069" Value="キレアジの上ヒレ"/>
+        <handlers:Item Key="item006A" Value="サシミウロコ"/>
+        <handlers:Item Key="item006B" Value="大サシミウロコ"/>
+        <handlers:Item Key="item006C" Value="バクヤクウロコ"/>
+        <handlers:Item Key="item006D" Value="大バクヤクウロコ"/>
+        <handlers:Item Key="item006E" Value="ハレツウロコ"/>
+        <handlers:Item Key="item006F" Value="大ハレツウロコ"/>
+        <handlers:Item Key="item0070" Value="バクレツウロコ"/>
+        <handlers:Item Key="item0071" Value="大バクレツウロコ"/>
+        <handlers:Item Key="item0072" Value="砥石"/>
+        <handlers:Item Key="item0073" Value="捕獲用ネット"/>
+        <handlers:Item Key="item0074" Value="釣り竿"/>
+        <handlers:Item Key="item0075" Value="肉焼きセット"/>
+        <handlers:Item Key="item0076" Value="隠れ身の装衣"/>
+        <handlers:Item Key="item0077" Value="転身の装衣"/>
+        <handlers:Item Key="item0078" Value="癒しの煙筒"/>
+        <handlers:Item Key="item0079" Value="不動の装衣"/>
+        <handlers:Item Key="item007A" Value="挑発の装衣"/>
+        <handlers:Item Key="item007B" Value="体力の装衣"/>
+        <handlers:Item Key="item007C" Value="耐熱の装衣"/>
+        <handlers:Item Key="item007D" Value="耐水の装衣"/>
+        <handlers:Item Key="item007E" Value="耐寒の装衣"/>
+        <handlers:Item Key="item007F" Value="耐雷の装衣"/>
+        <handlers:Item Key="item0080" Value="耐龍の装衣"/>
+        <handlers:Item Key="item0081" Value="解除の煙筒"/>
+        <handlers:Item Key="item0082" Value="滑空の装衣"/>
+        <handlers:Item Key="item0083" Value="回避の装衣"/>
+        <handlers:Item Key="item0084" Value="強打の装衣"/>
+        <handlers:Item Key="item0085" Value="化合の装衣"/>
+        <handlers:Item Key="item0086" Value="免疫の装衣"/>
+        <handlers:Item Key="item0087" Value="達人の煙筒"/>
+        <handlers:Item Key="item0088" Value="追い剥ぎの装衣"/>
+        <handlers:Item Key="item0089" Value="LV1 通常弾"/>
+        <handlers:Item Key="item008A" Value="LV2 通常弾"/>
+        <handlers:Item Key="item008B" Value="LV3 通常弾"/>
+        <handlers:Item Key="item008C" Value="LV1 貫通弾"/>
+        <handlers:Item Key="item008D" Value="LV2 貫通弾"/>
+        <handlers:Item Key="item008E" Value="LV3 貫通弾"/>
+        <handlers:Item Key="item008F" Value="LV1 散弾"/>
+        <handlers:Item Key="item0090" Value="LV2 散弾"/>
+        <handlers:Item Key="item0091" Value="LV3 散弾"/>
+        <handlers:Item Key="item0092" Value="LV1 徹甲榴弾"/>
+        <handlers:Item Key="item0093" Value="LV2 徹甲榴弾"/>
+        <handlers:Item Key="item0094" Value="LV3 徹甲榴弾"/>
+        <handlers:Item Key="item0095" Value="LV1 拡散弾"/>
+        <handlers:Item Key="item0096" Value="LV2 拡散弾"/>
+        <handlers:Item Key="item0097" Value="LV3 拡散弾"/>
+        <handlers:Item Key="item0098" Value="火炎弾"/>
+        <handlers:Item Key="item0099" Value="水冷弾"/>
+        <handlers:Item Key="item009A" Value="電撃弾"/>
+        <handlers:Item Key="item009B" Value="氷結弾"/>
+        <handlers:Item Key="item009C" Value="滅龍弾"/>
+        <handlers:Item Key="item009D" Value="LV1 毒弾"/>
+        <handlers:Item Key="item009E" Value="LV2 毒弾"/>
+        <handlers:Item Key="item009F" Value="LV1 麻痺弾"/>
+        <handlers:Item Key="item00A0" Value="LV2 麻痺弾"/>
+        <handlers:Item Key="item00A1" Value="LV1 睡眠弾"/>
+        <handlers:Item Key="item00A2" Value="LV2 睡眠弾"/>
+        <handlers:Item Key="item00A3" Value="LV1 減気弾"/>
+        <handlers:Item Key="item00A4" Value="LV2 減気弾"/>
+        <handlers:Item Key="item00A5" Value="LV1 回復弾"/>
+        <handlers:Item Key="item00A6" Value="LV2 回復弾"/>
+        <handlers:Item Key="item00A7" Value="竜撃弾"/>
+        <handlers:Item Key="item00A8" Value="斬裂弾"/>
+        <handlers:Item Key="item00A9" Value="捕獲用麻酔弾"/>
+        <handlers:Item Key="item00AA" Value="鬼人弾"/>
+        <handlers:Item Key="item00AB" Value="硬化弾"/>
+        <handlers:Item Key="item00AC" Value="ビン無し"/>
+        <handlers:Item Key="item00AD" Value="接撃ビン"/>
+        <handlers:Item Key="item00AE" Value="空きビン"/>
+        <handlers:Item Key="item00AF" Value="強撃ビン"/>
+        <handlers:Item Key="item00B0" Value="毒ビン"/>
+        <handlers:Item Key="item00B1" Value="麻痺ビン"/>
+        <handlers:Item Key="item00B2" Value="睡眠ビン"/>
+        <handlers:Item Key="item00B3" Value="Exhaust Coating"/>
+        <handlers:Item Key="item00B4" Value="爆破ビン"/>
+        <handlers:Item Key="item00B5" Value="応急薬"/>
+        <handlers:Item Key="item00B6" Value="応急薬グレート"/>
+        <handlers:Item Key="item00B7" Value="支給用携帯食料"/>
+        <handlers:Item Key="item00B8" Value="支給用生命の粉塵"/>
+        <handlers:Item Key="item00B9" Value="支給用秘薬"/>
+        <handlers:Item Key="item00BA" Value="支給用大タル爆弾"/>
+        <handlers:Item Key="item00BB" Value="支給用シビレ罠"/>
+        <handlers:Item Key="item00BC" Value="支給用落とし穴"/>
+        <handlers:Item Key="item00BD" Value="支給用漢方の粉塵"/>
+        <handlers:Item Key="item00BE" Value="支給用鬼人の粉塵"/>
+        <handlers:Item Key="item00BF" Value="支給用硬化の粉塵"/>
+        <handlers:Item Key="item00C0" Value="支給用こやし弾"/>
+        <handlers:Item Key="item00C1" Value="支給用閃光弾"/>
+        <handlers:Item Key="item00C2" Value="支給用音爆弾"/>
+        <handlers:Item Key="item00C3" Value="投げナイフ"/>
+        <handlers:Item Key="item00C4" Value="毒投げナイフ"/>
+        <handlers:Item Key="item00C5" Value="眠り投げナイフ"/>
+        <handlers:Item Key="item00C6" Value="麻痺投げナイフ"/>
+        <handlers:Item Key="item00C7" Value="捕獲用麻酔投げナイフ"/>
+        <handlers:Item Key="item00C8" Value="支給用モドリ玉"/>
+        <handlers:Item Key="item00C9" Value="支給用麻酔玉"/>
+        <handlers:Item Key="item00CA" Value="バリスタの弾"/>
+        <handlers:Item Key="item00CB" Value="単発式拘束弾"/>
+        <handlers:Item Key="item00CC" Value="大砲の弾"/>
+        <handlers:Item Key="item00CD" Value="鉄鉱石"/>
+        <handlers:Item Key="item00CE" Value="マカライト鉱石"/>
+        <handlers:Item Key="item00CF" Value="ドラグライト鉱石"/>
+        <handlers:Item Key="item00D0" Value="カブレライト鉱石"/>
+        <handlers:Item Key="item00D1" Value="ユニオン鉱石"/>
+        <handlers:Item Key="item00D2" Value="大地の結晶"/>
+        <handlers:Item Key="item00D3" Value="深海の結晶"/>
+        <handlers:Item Key="item00D4" Value="龍脈の結晶"/>
+        <handlers:Item Key="item00D5" Value="ライトクリスタル"/>
+        <handlers:Item Key="item00D6" Value="ノヴァクリスタル"/>
+        <handlers:Item Key="item00D7" Value="獄炎石"/>
+        <handlers:Item Key="item00D8" Value="水晶原石"/>
+        <handlers:Item Key="item00D9" Value="精晶原石"/>
+        <handlers:Item Key="item00DA" Value="幻晶原石"/>
+        <handlers:Item Key="item00DB" Value="龍晶原石"/>
+        <handlers:Item Key="item00DC" Value="鎧玉"/>
+        <handlers:Item Key="item00DD" Value="上鎧玉"/>
+        <handlers:Item Key="item00DE" Value="尖鎧玉"/>
+        <handlers:Item Key="item00DF" Value="堅鎧玉"/>
+        <handlers:Item Key="item00E0" Value="重鎧玉"/>
+        <handlers:Item Key="item00E1" Value="頑丈な骨"/>
+        <handlers:Item Key="item00E2" Value="上質な堅骨"/>
+        <handlers:Item Key="item00E3" Value="太古の大骨"/>
+        <handlers:Item Key="item00E4" Value="強固な岩骨"/>
+        <handlers:Item Key="item00E5" Value="サンゴの紅骨"/>
+        <handlers:Item Key="item00E6" Value="いびつな狂骨"/>
+        <handlers:Item Key="item00E7" Value="荒々しい蛮骨"/>
+        <handlers:Item Key="item00E8" Value="いにしえの龍骨"/>
+        <handlers:Item Key="item00E9" Value="なぞの頭骨"/>
+        <handlers:Item Key="item00EA" Value="オオツノアゲハ"/>
+        <handlers:Item Key="item00EB" Value="禍々しい布"/>
+        <handlers:Item Key="item00EC" Value="竜骨【小】"/>
+        <handlers:Item Key="item00ED" Value="竜骨【中】"/>
+        <handlers:Item Key="item00EE" Value="竜骨【大】"/>
+        <handlers:Item Key="item00EF" Value="上竜骨"/>
+        <handlers:Item Key="item00F0" Value="尖竜骨"/>
+        <handlers:Item Key="item00F1" Value="堅竜骨"/>
+        <handlers:Item Key="item00F2" Value="古龍骨"/>
+        <handlers:Item Key="item00F3" Value="とがった爪"/>
+        <handlers:Item Key="item00F4" Value="鋭利な爪"/>
+        <handlers:Item Key="item00F5" Value="モンスターの体液"/>
+        <handlers:Item Key="item00F6" Value="モンスターの濃汁"/>
+        <handlers:Item Key="item00F7" Value="毒袋"/>
+        <handlers:Item Key="item00F8" Value="猛毒袋"/>
+        <handlers:Item Key="item00F9" Value="麻痺袋"/>
+        <handlers:Item Key="item00FA" Value="強力麻痺袋"/>
+        <handlers:Item Key="item00FB" Value="睡眠袋"/>
+        <handlers:Item Key="item00FC" Value="昏睡袋"/>
+        <handlers:Item Key="item00FD" Value="火炎袋"/>
+        <handlers:Item Key="item00FE" Value="爆炎袋"/>
+        <handlers:Item Key="item00FF" Value="水袋"/>
+        <handlers:Item Key="item0100" Value="大水袋"/>
+        <handlers:Item Key="item0101" Value="氷結袋"/>
+        <handlers:Item Key="item0102" Value="凍結袋"/>
+        <handlers:Item Key="item0103" Value="電気袋"/>
+        <handlers:Item Key="item0104" Value="電撃袋"/>
+        <handlers:Item Key="item0105" Value="鳥竜玉"/>
+        <handlers:Item Key="item0106" Value="竜玉"/>
+        <handlers:Item Key="item0107" Value="古龍の血"/>
+        <handlers:Item Key="item0108" Value="モスの苔皮"/>
+        <handlers:Item Key="item0109" Value="暖かい毛皮"/>
+        <handlers:Item Key="item010A" Value="上質な毛皮"/>
+        <handlers:Item Key="item010B" Value="ランゴスタの甲殻"/>
+        <handlers:Item Key="item010C" Value="ランゴスタの堅殻"/>
+        <handlers:Item Key="item010D" Value="ランゴスタの羽"/>
+        <handlers:Item Key="item010E" Value="ランゴスタの薄羽"/>
+        <handlers:Item Key="item010F" Value="カンタロスの甲殻"/>
+        <handlers:Item Key="item0110" Value="カンタロスの羽"/>
+        <handlers:Item Key="item0111" Value="カンタロスの頭"/>
+        <handlers:Item Key="item0112" Value="カンタロスの堅殻"/>
+        <handlers:Item Key="item0113" Value="カンタロスの薄羽"/>
+        <handlers:Item Key="item0114" Value="咬魚の皮"/>
+        <handlers:Item Key="item0115" Value="咬魚のヒゲ"/>
+        <handlers:Item Key="item0116" Value="咬魚の上皮"/>
+        <handlers:Item Key="item0117" Value="咬魚の大ヒゲ"/>
+        <handlers:Item Key="item0118" Value="翼竜の皮"/>
+        <handlers:Item Key="item0119" Value="翼竜の上皮"/>
+        <handlers:Item Key="item011A" Value="バルノスの上皮"/>
+        <handlers:Item Key="item011B" Value="バルノスの尖爪"/>
+        <handlers:Item Key="item011C" Value="ケストドンの甲殻"/>
+        <handlers:Item Key="item011D" Value="ケストドンの頭殻"/>
+        <handlers:Item Key="item011E" Value="ケストドンの堅殻"/>
+        <handlers:Item Key="item011F" Value="ガストドンの堅殻"/>
+        <handlers:Item Key="item0120" Value="ガストドンの尖角"/>
+        <handlers:Item Key="item0121" Value="ジャグラスの鱗"/>
+        <handlers:Item Key="item0122" Value="ジャグラスの皮"/>
+        <handlers:Item Key="item0123" Value="ジャグラスの上鱗"/>
+        <handlers:Item Key="item0124" Value="ジャグラスの上皮"/>
+        <handlers:Item Key="item0125" Value="シャムオスの鱗"/>
+        <handlers:Item Key="item0126" Value="シャムオスの皮"/>
+        <handlers:Item Key="item0127" Value="シャムオスの上鱗"/>
+        <handlers:Item Key="item0128" Value="シャムオスの上皮"/>
+        <handlers:Item Key="item0129" Value="ギルオスの鱗"/>
+        <handlers:Item Key="item012A" Value="ギルオスの皮"/>
+        <handlers:Item Key="item012B" Value="ギルオスの麻痺牙"/>
+        <handlers:Item Key="item012C" Value="ギルオスの上鱗"/>
+        <handlers:Item Key="item012D" Value="ギルオスの上皮"/>
+        <handlers:Item Key="item012E" Value="賊竜の鱗"/>
+        <handlers:Item Key="item012F" Value="賊竜の皮"/>
+        <handlers:Item Key="item0130" Value="賊竜のたてがみ"/>
+        <handlers:Item Key="item0131" Value="賊竜の爪"/>
+        <handlers:Item Key="item0132" Value="賊竜の上鱗"/>
+        <handlers:Item Key="item0133" Value="賊竜の上皮"/>
+        <handlers:Item Key="item0134" Value="賊竜の尖爪"/>
+        <handlers:Item Key="item0135" Value="掻鳥の鱗"/>
+        <handlers:Item Key="item0136" Value="掻鳥の皮"/>
+        <handlers:Item Key="item0137" Value="掻鳥の飾り羽"/>
+        <handlers:Item Key="item0138" Value="掻鳥のクチバシ"/>
+        <handlers:Item Key="item0139" Value="掻鳥の上鱗"/>
+        <handlers:Item Key="item013A" Value="掻鳥の上皮"/>
+        <handlers:Item Key="item013B" Value="掻鳥の大飾り羽"/>
+        <handlers:Item Key="item013C" Value="掻鳥の大クチバシ"/>
+        <handlers:Item Key="item013D" Value="毒妖鳥の鱗"/>
+        <handlers:Item Key="item013E" Value="毒妖鳥の甲殻"/>
+        <handlers:Item Key="item013F" Value="毒妖鳥の羽根"/>
+        <handlers:Item Key="item0140" Value="毒妖鳥の喉袋"/>
+        <handlers:Item Key="item0141" Value="毒妖鳥の尻尾"/>
+        <handlers:Item Key="item0142" Value="毒妖鳥の上鱗"/>
+        <handlers:Item Key="item0143" Value="毒妖鳥の堅殻"/>
+        <handlers:Item Key="item0144" Value="毒妖鳥の翼"/>
+        <handlers:Item Key="item0145" Value="毒妖鳥の大喉袋"/>
+        <handlers:Item Key="item0146" Value="土砂竜の甲殻"/>
+        <handlers:Item Key="item0147" Value="土砂竜の背甲"/>
+        <handlers:Item Key="item0148" Value="土砂竜の爪"/>
+        <handlers:Item Key="item0149" Value="土砂竜の頭殻"/>
+        <handlers:Item Key="item014A" Value="土砂竜の尻尾"/>
+        <handlers:Item Key="item014B" Value="肥沃なドロ"/>
+        <handlers:Item Key="item014C" Value="土砂竜の堅殻"/>
+        <handlers:Item Key="item014D" Value="土砂竜の堅甲"/>
+        <handlers:Item Key="item014E" Value="土砂竜の鋭爪"/>
+        <handlers:Item Key="item014F" Value="泥魚竜の鱗"/>
+        <handlers:Item Key="item0150" Value="泥魚竜の甲殻"/>
+        <handlers:Item Key="item0151" Value="泥魚竜の牙"/>
+        <handlers:Item Key="item0152" Value="泥魚竜のヒレ"/>
+        <handlers:Item Key="item0153" Value="泥魚竜の上鱗"/>
+        <handlers:Item Key="item0154" Value="泥魚竜の堅殻"/>
+        <handlers:Item Key="item0155" Value="泥魚竜の鋭牙"/>
+        <handlers:Item Key="item0156" Value="泥魚竜の上ヒレ"/>
+        <handlers:Item Key="item0157" Value="飛雷竜の鱗"/>
+        <handlers:Item Key="item0158" Value="飛雷竜の毛皮"/>
+        <handlers:Item Key="item0159" Value="飛雷竜の皮膜"/>
+        <handlers:Item Key="item015A" Value="飛雷竜の爪"/>
+        <handlers:Item Key="item015B" Value="飛雷竜の電極針"/>
+        <handlers:Item Key="item015C" Value="飛雷竜の上鱗"/>
+        <handlers:Item Key="item015D" Value="飛雷竜の上毛皮"/>
+        <handlers:Item Key="item015E" Value="飛雷竜の尖爪"/>
+        <handlers:Item Key="item015F" Value="飛雷竜の雷極針"/>
+        <handlers:Item Key="item0160" Value="蛮顎竜の鱗"/>
+        <handlers:Item Key="item0161" Value="蛮顎竜の毛皮"/>
+        <handlers:Item Key="item0162" Value="蛮顎竜の牙"/>
+        <handlers:Item Key="item0163" Value="蛮顎竜の鼻骨"/>
+        <handlers:Item Key="item0164" Value="蛮顎竜の尻尾"/>
+        <handlers:Item Key="item0165" Value="蛮顎竜の逆鱗"/>
+        <handlers:Item Key="item0166" Value="蛮顎竜の上鱗"/>
+        <handlers:Item Key="item0167" Value="蛮顎竜の上毛皮"/>
+        <handlers:Item Key="item0168" Value="蛮顎竜の鋭牙"/>
+        <handlers:Item Key="item0169" Value="蛮顎竜の大鼻骨"/>
+        <handlers:Item Key="item016A" Value="蛮顎竜の宝玉"/>
+        <handlers:Item Key="item016B" Value="雌火竜の鱗"/>
+        <handlers:Item Key="item016C" Value="雌火竜の甲殻"/>
+        <handlers:Item Key="item016D" Value="雌火竜の翼膜"/>
+        <handlers:Item Key="item016E" Value="雌火竜の棘"/>
+        <handlers:Item Key="item016F" Value="雌火竜の逆鱗"/>
+        <handlers:Item Key="item0170" Value="雌火竜の上鱗"/>
+        <handlers:Item Key="item0171" Value="雌火竜の堅殻"/>
+        <handlers:Item Key="item0172" Value="雌火竜の上棘"/>
+        <handlers:Item Key="item0173" Value="雌火竜の紅玉"/>
+        <handlers:Item Key="item0174" Value="桜火竜の上鱗"/>
+        <handlers:Item Key="item0175" Value="桜火竜の堅殻"/>
+        <handlers:Item Key="item0176" Value="眩鳥の鱗"/>
+        <handlers:Item Key="item0177" Value="眩鳥の皮"/>
+        <handlers:Item Key="item0178" Value="眩鳥の爪"/>
+        <handlers:Item Key="item0179" Value="眩鳥の発光膜"/>
+        <handlers:Item Key="item017A" Value="眩鳥の上鱗"/>
+        <handlers:Item Key="item017B" Value="眩鳥の上皮"/>
+        <handlers:Item Key="item017C" Value="眩鳥の尖爪"/>
+        <handlers:Item Key="item017D" Value="眩鳥の閃光膜"/>
+        <handlers:Item Key="item017E" Value="浮空竜の毛皮"/>
+        <handlers:Item Key="item017F" Value="浮空竜の鱗"/>
+        <handlers:Item Key="item0180" Value="ゴム質の甲殻"/>
+        <handlers:Item Key="item0181" Value="浮空竜の翼膜"/>
+        <handlers:Item Key="item0182" Value="浮空竜の上毛皮"/>
+        <handlers:Item Key="item0183" Value="浮空竜の上鱗"/>
+        <handlers:Item Key="item0184" Value="ゴム質の堅殻"/>
+        <handlers:Item Key="item0185" Value="浮空竜の翼"/>
+        <handlers:Item Key="item0186" Value="痺賊竜の鱗"/>
+        <handlers:Item Key="item0187" Value="痺賊竜の皮"/>
+        <handlers:Item Key="item0188" Value="痺賊竜の頭巾殻"/>
+        <handlers:Item Key="item0189" Value="痺賊竜の牙"/>
+        <handlers:Item Key="item018A" Value="痺賊竜の尻尾"/>
+        <handlers:Item Key="item018B" Value="痺賊竜の上鱗"/>
+        <handlers:Item Key="item018C" Value="痺賊竜の上皮"/>
+        <handlers:Item Key="item018D" Value="痺賊竜の大頭巾"/>
+        <handlers:Item Key="item018E" Value="痺賊竜の鋭牙"/>
+        <handlers:Item Key="item018F" Value="骨鎚竜の鱗"/>
+        <handlers:Item Key="item0190" Value="骨鎚竜の甲殻"/>
+        <handlers:Item Key="item0191" Value="骨鎚竜の黒油殻"/>
+        <handlers:Item Key="item0192" Value="竜骨塊"/>
+        <handlers:Item Key="item0193" Value="Radobaan Jaw"/>
+        <handlers:Item Key="item0194" Value="骨鎚竜の骨髄"/>
+        <handlers:Item Key="item0195" Value="骨鎚竜の上鱗"/>
+        <handlers:Item Key="item0196" Value="骨鎚竜の堅殻"/>
+        <handlers:Item Key="item0197" Value="骨鎚竜の延髄"/>
+        <handlers:Item Key="item0198" Value="風漂竜の鱗"/>
+        <handlers:Item Key="item0199" Value="風漂竜の皮"/>
+        <handlers:Item Key="item019A" Value="風漂竜の爪"/>
+        <handlers:Item Key="item019B" Value="風漂竜の翼膜"/>
+        <handlers:Item Key="item019C" Value="風漂竜の尾膜"/>
+        <handlers:Item Key="item019D" Value="風漂竜の逆鱗"/>
+        <handlers:Item Key="item019E" Value="風漂竜の上鱗"/>
+        <handlers:Item Key="item019F" Value="風漂竜の上皮"/>
+        <handlers:Item Key="item01A0" Value="風漂竜の尖爪"/>
+        <handlers:Item Key="item01A1" Value="風漂竜の翼"/>
+        <handlers:Item Key="item01A2" Value="風漂竜の宝玉"/>
+        <handlers:Item Key="item01A3" Value="惨爪竜の鱗"/>
+        <handlers:Item Key="item01A4" Value="惨爪竜の硬筋"/>
+        <handlers:Item Key="item01A5" Value="惨爪竜の爪"/>
+        <handlers:Item Key="item01A6" Value="惨爪竜の牙"/>
+        <handlers:Item Key="item01A7" Value="惨爪竜の尻尾"/>
+        <handlers:Item Key="item01A8" Value="惨爪竜の逆鱗"/>
+        <handlers:Item Key="item01A9" Value="惨爪竜の上鱗"/>
+        <handlers:Item Key="item01AA" Value="惨爪竜の大硬筋"/>
+        <handlers:Item Key="item01AB" Value="惨爪竜の尖爪"/>
+        <handlers:Item Key="item01AC" Value="惨爪竜の鋭牙"/>
+        <handlers:Item Key="item01AD" Value="惨爪竜の宝玉"/>
+        <handlers:Item Key="item01AE" Value="火竜の鱗"/>
+        <handlers:Item Key="item01AF" Value="火竜の甲殻"/>
+        <handlers:Item Key="item01B0" Value="火竜の翼膜"/>
+        <handlers:Item Key="item01B1" Value="火竜の尻尾"/>
+        <handlers:Item Key="item01B2" Value="火竜の翼爪"/>
+        <handlers:Item Key="item01B3" Value="火竜の骨髄"/>
+        <handlers:Item Key="item01B4" Value="火竜の逆鱗"/>
+        <handlers:Item Key="item01B5" Value="火竜の上鱗"/>
+        <handlers:Item Key="item01B6" Value="火竜の堅殻"/>
+        <handlers:Item Key="item01B7" Value="火竜の翼"/>
+        <handlers:Item Key="item01B8" Value="火竜の延髄"/>
+        <handlers:Item Key="item01B9" Value="火竜の紅玉"/>
+        <handlers:Item Key="item01BA" Value="蒼火竜の上鱗"/>
+        <handlers:Item Key="item01BB" Value="蒼火竜の堅殻"/>
+        <handlers:Item Key="item01BC" Value="蒼火竜の尻尾"/>
+        <handlers:Item Key="item01BD" Value="蒼火竜の翼"/>
+        <handlers:Item Key="item01BE" Value="角竜の甲殻"/>
+        <handlers:Item Key="item01BF" Value="角竜の背甲"/>
+        <handlers:Item Key="item01C0" Value="角竜の尾甲"/>
+        <handlers:Item Key="item01C1" Value="角竜の牙"/>
+        <handlers:Item Key="item01C2" Value="ねじれた角"/>
+        <handlers:Item Key="item01C3" Value="角竜の骨髄"/>
+        <handlers:Item Key="item01C4" Value="角竜の堅殻"/>
+        <handlers:Item Key="item01C5" Value="角竜の堅甲"/>
+        <handlers:Item Key="item01C6" Value="上質なねじれた角"/>
+        <handlers:Item Key="item01C7" Value="角竜の延髄"/>
+        <handlers:Item Key="item01C8" Value="黒角竜の堅殻"/>
+        <handlers:Item Key="item01C9" Value="黒角竜の堅甲"/>
+        <handlers:Item Key="item01CA" Value="上質な黒巻き角"/>
+        <handlers:Item Key="item01CB" Value="幻獣の皮"/>
+        <handlers:Item Key="item01CC" Value="幻獣の尾"/>
+        <handlers:Item Key="item01CD" Value="幻獣のたてがみ"/>
+        <handlers:Item Key="item01CE" Value="幻獣の雷角"/>
+        <handlers:Item Key="item01CF" Value="幻獣の上皮"/>
+        <handlers:Item Key="item01D0" Value="幻獣の雷尾"/>
+        <handlers:Item Key="item01D1" Value="幻獣の蒼角"/>
+        <handlers:Item Key="item01D2" Value="Zorah Magdaros Inner Scale"/>
+        <handlers:Item Key="item01D3" Value="熔山龍の熱鱗"/>
+        <handlers:Item Key="item01D4" Value="熔山龍の岩殻"/>
+        <handlers:Item Key="item01D5" Value="熔山龍の背甲"/>
+        <handlers:Item Key="item01D6" Value="熔山龍の胸殻"/>
+        <handlers:Item Key="item01D7" Value="Zorah Magdaros Brace"/>
+        <handlers:Item Key="item01D8" Value="熔山龍のマグマ"/>
+        <handlers:Item Key="item01D9" Value="熔山龍の宝玉"/>
+        <handlers:Item Key="item01DA" Value="岩賊竜の上鱗"/>
+        <handlers:Item Key="item01DB" Value="岩賊竜の上皮"/>
+        <handlers:Item Key="item01DC" Value="岩賊竜の顎"/>
+        <handlers:Item Key="item01DD" Value="岩賊竜の尖爪"/>
+        <handlers:Item Key="item01DE" Value="岩賊竜の尻尾"/>
+        <handlers:Item Key="item01DF" Value="溶岩竜の上鱗"/>
+        <handlers:Item Key="item01E0" Value="溶岩竜の堅殻"/>
+        <handlers:Item Key="item01E1" Value="溶岩竜の鋭牙"/>
+        <handlers:Item Key="item01E2" Value="溶岩竜の上ヒレ"/>
+        <handlers:Item Key="item01E3" Value="爆鎚竜の上鱗"/>
+        <handlers:Item Key="item01E4" Value="爆鎚竜の堅殻"/>
+        <handlers:Item Key="item01E5" Value="爆鎚竜の顎"/>
+        <handlers:Item Key="item01E6" Value="爆鎚竜の耐熱殻"/>
+        <handlers:Item Key="item01E7" Value="爆鎚竜の延髄"/>
+        <handlers:Item Key="item01E8" Value="爆鎚竜の紅玉"/>
+        <handlers:Item Key="item01E9" Value="溶岩塊"/>
+        <handlers:Item Key="item01EA" Value="爆鱗竜の上鱗"/>
+        <handlers:Item Key="item01EB" Value="爆鱗竜の堅殻"/>
+        <handlers:Item Key="item01EC" Value="爆鱗竜の尻尾"/>
+        <handlers:Item Key="item01ED" Value="爆鱗竜の爆腺"/>
+        <handlers:Item Key="item01EE" Value="爆鱗竜の尖爪"/>
+        <handlers:Item Key="item01EF" Value="爆鱗竜の翼"/>
+        <handlers:Item Key="item01F0" Value="爆鱗竜の宝玉"/>
+        <handlers:Item Key="item01F1" Value="不滅の龍鱗"/>
+        <handlers:Item Key="item01F2" Value="滅尽龍の堅殻"/>
+        <handlers:Item Key="item01F3" Value="Nergigante Barbs"/>
+        <handlers:Item Key="item01F4" Value="滅尽龍の尻尾"/>
+        <handlers:Item Key="item01F5" Value="滅尽龍の大角"/>
+        <handlers:Item Key="item01F6" Value="滅尽龍の尖爪"/>
+        <handlers:Item Key="item01F7" Value="滅尽龍の再生殻"/>
+        <handlers:Item Key="item01F8" Value="滅尽龍の宝玉"/>
+        <handlers:Item Key="item01F9" Value="死屍の龍鱗"/>
+        <handlers:Item Key="item01FA" Value="屍套龍の堅殻"/>
+        <handlers:Item Key="item01FB" Value="屍套龍の被膜"/>
+        <handlers:Item Key="item01FC" Value="屍套龍の尻尾"/>
+        <handlers:Item Key="item01FD" Value="屍套龍の鋭牙"/>
+        <handlers:Item Key="item01FE" Value="屍套龍の尖爪"/>
+        <handlers:Item Key="item01FF" Value="屍套龍の翼"/>
+        <handlers:Item Key="item0200" Value="Vaal Hazak Miasmacryst"/>
+        <handlers:Item Key="item0201" Value="屍套龍の宝玉"/>
+        <handlers:Item Key="item0202" Value="炎王龍の堅殻"/>
+        <handlers:Item Key="item0203" Value="炎王龍のたてがみ"/>
+        <handlers:Item Key="item0204" Value="炎王龍の尻尾"/>
+        <handlers:Item Key="item0205" Value="炎王龍の尖角"/>
+        <handlers:Item Key="item0206" Value="獄炎の龍鱗"/>
+        <handlers:Item Key="item0207" Value="炎龍の尖爪"/>
+        <handlers:Item Key="item0208" Value="炎龍の翼"/>
+        <handlers:Item Key="item0209" Value="炎龍の塵粉"/>
+        <handlers:Item Key="item020A" Value="炎龍の宝玉"/>
+        <handlers:Item Key="item020B" Value="鋼龍の堅殻"/>
+        <handlers:Item Key="item020C" Value="鋼の上龍鱗"/>
+        <handlers:Item Key="item020D" Value="鋼龍の翼"/>
+        <handlers:Item Key="item020E" Value="鋼龍の尖角"/>
+        <handlers:Item Key="item020F" Value="鋼龍の尻尾"/>
+        <handlers:Item Key="item0210" Value="鋼龍の尖爪"/>
+        <handlers:Item Key="item0211" Value="鋼龍の宝玉"/>
+        <handlers:Item Key="item0212" Value="冥灯龍の幽鱗"/>
+        <handlers:Item Key="item0213" Value="冥灯龍の白殻"/>
+        <handlers:Item Key="item0214" Value="冥灯龍の幽幕"/>
+        <handlers:Item Key="item0215" Value="冥灯龍の尻尾"/>
+        <handlers:Item Key="item0216" Value="冥灯龍の幽角"/>
+        <handlers:Item Key="item0217" Value="冥灯龍の幽爪"/>
+        <handlers:Item Key="item0218" Value="冥灯龍の幽翼"/>
+        <handlers:Item Key="item0219" Value="Xeno'jiva Crystal"/>
+        <handlers:Item Key="item021A" Value="冥灯龍の幽玉"/>
+        <handlers:Item Key="item021B" Value="？？？の鱗"/>
+        <handlers:Item Key="item021C" Value="？？？の甲殻"/>
+        <handlers:Item Key="item021D" Value="？？？の皮膜"/>
+        <handlers:Item Key="item021E" Value="？？？の尻尾"/>
+        <handlers:Item Key="item021F" Value="？？？の角"/>
+        <handlers:Item Key="item0220" Value="？？？の爪"/>
+        <handlers:Item Key="item0221" Value="？？？の翼"/>
+        <handlers:Item Key="item0222" Value="??? Crystal"/>
+        <handlers:Item Key="item0223" Value="？？？の宝玉"/>
+        <handlers:Item Key="item0224" Value="なぞの珠"/>
+        <handlers:Item Key="item0225" Value="光る珠"/>
+        <handlers:Item Key="item0226" Value="古びた珠"/>
+        <handlers:Item Key="item0227" Value="風化した珠"/>
+        <handlers:Item Key="item0228" Value="汚れた龍脈石"/>
+        <handlers:Item Key="item0229" Value="輝く龍脈石"/>
+        <handlers:Item Key="item022A" Value="龍脈石のかけら"/>
+        <handlers:Item Key="item022B" Value="龍脈石"/>
+        <handlers:Item Key="item022C" Value="大龍脈石"/>
+        <handlers:Item Key="item022D" Value="猛者の龍脈石・剣"/>
+        <handlers:Item Key="item022E" Value="猛者の龍脈石・刃"/>
+        <handlers:Item Key="item022F" Value="猛者の龍脈石・鎚"/>
+        <handlers:Item Key="item0230" Value="猛者の龍脈石・槍"/>
+        <handlers:Item Key="item0231" Value="猛者の龍脈石・斧"/>
+        <handlers:Item Key="item0232" Value="猛者の龍脈石・柄"/>
+        <handlers:Item Key="item0233" Value="猛者の龍脈石・弩"/>
+        <handlers:Item Key="item0234" Value="英雄の龍脈石・剣"/>
+        <handlers:Item Key="item0235" Value="英雄の龍脈石・刃"/>
+        <handlers:Item Key="item0236" Value="英雄の龍脈石・鎚"/>
+        <handlers:Item Key="item0237" Value="英雄の龍脈石・槍"/>
+        <handlers:Item Key="item0238" Value="英雄の龍脈石・斧"/>
+        <handlers:Item Key="item0239" Value="英雄の龍脈石・柄"/>
+        <handlers:Item Key="item023A" Value="英雄の龍脈石・弩"/>
+        <handlers:Item Key="item023B" Value="お食事券"/>
+        <handlers:Item Key="item023C" Value="古代竜人の手形"/>
+        <handlers:Item Key="item023D" Value="古代竜人の手形Ｇ"/>
+        <handlers:Item Key="item023E" Value="鋼の竜人手形"/>
+        <handlers:Item Key="item023F" Value="銀の竜人手形"/>
+        <handlers:Item Key="item0240" Value="金の竜人手形"/>
+        <handlers:Item Key="item0241" Value="勇気の証"/>
+        <handlers:Item Key="item0242" Value="勇気の証Ｇ"/>
+        <handlers:Item Key="item0243" Value="調査団チケット"/>
+        <handlers:Item Key="item0244" Value="プケプケコイン"/>
+        <handlers:Item Key="item0245" Value="クルルコイン"/>
+        <handlers:Item Key="item0246" Value="レイアコイン"/>
+        <handlers:Item Key="item0247" Value="ツィツィコイン"/>
+        <handlers:Item Key="item0248" Value="ボロスコイン"/>
+        <handlers:Item Key="item0249" Value="ガマルコイン"/>
+        <handlers:Item Key="item024A" Value="レウスコイン"/>
+        <handlers:Item Key="item024B" Value="獣竜コイン"/>
+        <handlers:Item Key="item024C" Value="飛竜コイン"/>
+        <handlers:Item Key="item024D" Value="闘技王のコイン"/>
+        <handlers:Item Key="item024E" Value="狩猟王のコイン"/>
+        <handlers:Item Key="item024F" Value="撃龍王のコイン"/>
+        <handlers:Item Key="item0250" Value="鋼のたまご"/>
+        <handlers:Item Key="item0251" Value="銀のたまご"/>
+        <handlers:Item Key="item0252" Value="金のたまご"/>
+        <handlers:Item Key="item0253" Value="欠けたウロコ"/>
+        <handlers:Item Key="item0254" Value="大きなウロコ"/>
+        <handlers:Item Key="item0255" Value="きれいなウロコ"/>
+        <handlers:Item Key="item0256" Value="つやめくウロコ"/>
+        <handlers:Item Key="item0257" Value="かがやくウロコ"/>
+        <handlers:Item Key="item0258" Value="ベルナストーン"/>
+        <handlers:Item Key="item0259" Value="ドンドルマリン"/>
+        <handlers:Item Key="item025A" Value="ロックラック鉱"/>
+        <handlers:Item Key="item025B" Value="バルバレクォーツ"/>
+        <handlers:Item Key="item025C" Value="ミナガルデナイト"/>
+        <handlers:Item Key="item025D" Value="黄金のウロコ"/>
+        <handlers:Item Key="item025E" Value="黄金の大ウロコ"/>
+        <handlers:Item Key="item025F" Value="白金のウロコ"/>
+        <handlers:Item Key="item0260" Value="白金の大ウロコ"/>
+        <handlers:Item Key="item0261" Value="金色のウロコ"/>
+        <handlers:Item Key="item0262" Value="金色の大ウロコ"/>
+        <handlers:Item Key="item0263" Value="ホワイトレバー"/>
+        <handlers:Item Key="item0264" Value="竜のナミダ"/>
+        <handlers:Item Key="item0265" Value="竜の大粒ナミダ"/>
+        <handlers:Item Key="item0266" Value="龍秘宝"/>
+        <handlers:Item Key="item0267" Value="Old Dragon Treasure"/>
+        <handlers:Item Key="item0268" Value="サニーフラワー"/>
+        <handlers:Item Key="item0269" Value="シャインフラワー"/>
+        <handlers:Item Key="item026A" Value="ゴールドフラワー"/>
+        <handlers:Item Key="item026B" Value="特産スジタケ"/>
+        <handlers:Item Key="item026C" Value="厳選スジタケ"/>
+        <handlers:Item Key="item026D" Value="霊光スジタケ"/>
+        <handlers:Item Key="item026E" Value="小玉サボテン"/>
+        <handlers:Item Key="item026F" Value="大玉サボテン"/>
+        <handlers:Item Key="item0270" Value="王様サボテン"/>
+        <handlers:Item Key="item0271" Value="ハードフルーツ"/>
+        <handlers:Item Key="item0272" Value="ロックフルーツ"/>
+        <handlers:Item Key="item0273" Value="ワイルドフルーツ"/>
+        <handlers:Item Key="item0274" Value="特産ツボアワビ"/>
+        <handlers:Item Key="item0275" Value="厳選ツボアワビ"/>
+        <handlers:Item Key="item0276" Value="秘蔵ツボアワビ"/>
+        <handlers:Item Key="item0277" Value="ライトパール"/>
+        <handlers:Item Key="item0278" Value="ディープパール"/>
+        <handlers:Item Key="item0279" Value="イノセントパール"/>
+        <handlers:Item Key="item027A" Value="いにしえの化石"/>
+        <handlers:Item Key="item027B" Value="まぼろしの化石"/>
+        <handlers:Item Key="item027C" Value="神秘の化石"/>
+        <handlers:Item Key="item027D" Value="地下の果実"/>
+        <handlers:Item Key="item027E" Value="瘴気の果実"/>
+        <handlers:Item Key="item027F" Value="彼岸の果実"/>
+        <handlers:Item Key="item0280" Value="大地のコハク"/>
+        <handlers:Item Key="item0281" Value="龍脈のコハク"/>
+        <handlers:Item Key="item0282" Value="太古のコハク"/>
+        <handlers:Item Key="item0283" Value="ブルーマリン"/>
+        <handlers:Item Key="item0284" Value="トゥルーマリン"/>
+        <handlers:Item Key="item0285" Value="アビスマリン"/>
+        <handlers:Item Key="item0286" Value="百陽草"/>
+        <handlers:Item Key="item0287" Value="月夜茸"/>
+        <handlers:Item Key="item0288" Value="ドラゴンフラワー"/>
+        <handlers:Item Key="item0289" Value="トロピカパイン"/>
+        <handlers:Item Key="item028A" Value="藤色ツボアワビ"/>
+        <handlers:Item Key="item028B" Value="プラチナパール"/>
+        <handlers:Item Key="item028C" Value="魔の化石"/>
+        <handlers:Item Key="item028D" Value="ヘブンベリー"/>
+        <handlers:Item Key="item028E" Value="黄昏の石"/>
+        <handlers:Item Key="item028F" Value="ノアストーン"/>
+        <handlers:Item Key="item0290" Value="飛竜の卵"/>
+        <handlers:Item Key="item0291" Value="草食竜の卵"/>
+        <handlers:Item Key="item0292" Value="肉の塊"/>
+        <handlers:Item Key="item0293" Value="ヨリミチウサギ"/>
+        <handlers:Item Key="item0294" Value="ミチビキウサギ"/>
+        <handlers:Item Key="item0295" Value="シンリンシソチョウ"/>
+        <handlers:Item Key="item0296" Value="コダイジュノツカイ"/>
+        <handlers:Item Key="item0297" Value="コバルトモルフォ"/>
+        <handlers:Item Key="item0298" Value="マボロシモルフォ"/>
+        <handlers:Item Key="item0299" Value="ナキキノボリウオ"/>
+        <handlers:Item Key="item029A" Value="モリゲッコー"/>
+        <handlers:Item Key="item029B" Value="アリヅカゲッコー"/>
+        <handlers:Item Key="item029C" Value="クラヤミゲッコー"/>
+        <handlers:Item Key="item029D" Value="月光ゲッコー"/>
+        <handlers:Item Key="item029E" Value="カスミジョロウ"/>
+        <handlers:Item Key="item029F" Value="スカベンチュラ"/>
+        <handlers:Item Key="item02A0" Value="ニクイドリ"/>
+        <handlers:Item Key="item02A1" Value="トウゲンチョウ"/>
+        <handlers:Item Key="item02A2" Value="キザシヤンマ"/>
+        <handlers:Item Key="item02A3" Value="キッチョウヤンマ"/>
+        <handlers:Item Key="item02A4" Value="ウロコウモリ"/>
+        <handlers:Item Key="item02A5" Value="フンコロガシ"/>
+        <handlers:Item Key="item02A6" Value="バクダンイワコロガシ"/>
+        <handlers:Item Key="item02A7" Value="ピンクパレクス"/>
+        <handlers:Item Key="item02A8" Value="ドスピンクパレクス"/>
+        <handlers:Item Key="item02A9" Value="ハレツアロワナ"/>
+        <handlers:Item Key="item02AA" Value="バクレツアロワナ"/>
+        <handlers:Item Key="item02AB" Value="ドスハレツアロワナ"/>
+        <handlers:Item Key="item02AC" Value="ドスバクレツアロワナ"/>
+        <handlers:Item Key="item02AD" Value="ドレスサンゴドリ"/>
+        <handlers:Item Key="item02AE" Value="タキシードサンゴドリ"/>
+        <handlers:Item Key="item02AF" Value="アンドンウオ"/>
+        <handlers:Item Key="item02B0" Value="フワフワクイナ"/>
+        <handlers:Item Key="item02B1" Value="ゴワゴワクイナ"/>
+        <handlers:Item Key="item02B2" Value="ホッピングッピー"/>
+        <handlers:Item Key="item02B3" Value="カセキカンス"/>
+        <handlers:Item Key="item02B4" Value="シビレガスガエル"/>
+        <handlers:Item Key="item02B5" Value="ネムリガスガエル"/>
+        <handlers:Item Key="item02B6" Value="ニトロガスガエル"/>
+        <handlers:Item Key="item02B7" Value="ユラユラ"/>
+        <handlers:Item Key="item02B8" Value="ユラユラクイーン"/>
+        <handlers:Item Key="item02B9" Value="回復ミツムシ"/>
+        <handlers:Item Key="item02BA" Value="大回復ミツムシ"/>
+        <handlers:Item Key="item02BB" Value="オソラノエボシ"/>
+        <handlers:Item Key="item02BC" Value="ハコビアリ"/>
+        <handlers:Item Key="item02BD" Value="ドスヘラクレス"/>
+        <handlers:Item Key="item02BE" Value="ゴールデンヘラクレス"/>
+        <handlers:Item Key="item02BF" Value="虹色ドスヘラクレス"/>
+        <handlers:Item Key="item02C0" Value="皇帝バッタ"/>
+        <handlers:Item Key="item02C1" Value="暴君バッタ"/>
+        <handlers:Item Key="item02C2" Value="閃光羽虫"/>
+        <handlers:Item Key="item02C3" Value="ムカシマンタゲラ"/>
+        <handlers:Item Key="item02C4" Value="テツカブトガニ"/>
+        <handlers:Item Key="item02C5" Value="ヘイタイカブトガニ"/>
+        <handlers:Item Key="item02C6" Value="エメラルドカブトガニ"/>
+        <handlers:Item Key="item02C7" Value="キレアジ"/>
+        <handlers:Item Key="item02C8" Value="ドスキレアジ"/>
+        <handlers:Item Key="item02C9" Value="大食いマグロ"/>
+        <handlers:Item Key="item02CA" Value="ドス大食いマグロ"/>
+        <handlers:Item Key="item02CB" Value="ダイオウカジキ"/>
+        <handlers:Item Key="item02CC" Value="ドスダイオウカジキ"/>
+        <handlers:Item Key="item02CD" Value="黄金魚"/>
+        <handlers:Item Key="item02CE" Value="白金魚"/>
+        <handlers:Item Key="item02CF" Value="ドス黄金魚"/>
+        <handlers:Item Key="item02D0" Value="ドス白金魚"/>
+        <handlers:Item Key="item02D1" Value="小金魚"/>
+        <handlers:Item Key="item02D2" Value="ドス小金魚"/>
+        <handlers:Item Key="item02D3" Value="サシミウオ"/>
+        <handlers:Item Key="item02D4" Value="ドスサシミウオ"/>
+        <handlers:Item Key="item02D5" Value="バクヤクデメキン"/>
+        <handlers:Item Key="item02D6" Value="ドスバクヤクデメキン"/>
+        <handlers:Item Key="item02D7" Value="耐毒珠【１】"/>
+        <handlers:Item Key="item02D8" Value="耐麻珠【１】"/>
+        <handlers:Item Key="item02D9" Value="耐眠珠【１】"/>
+        <handlers:Item Key="item02DA" Value="耐絶珠【１】"/>
+        <handlers:Item Key="item02DB" Value="耐爆珠【１】"/>
+        <handlers:Item Key="item02DC" Value="耐裂珠【１】"/>
+        <handlers:Item Key="item02DD" Value="耐防珠【１】"/>
+        <handlers:Item Key="item02DE" Value="防音珠【３】"/>
+        <handlers:Item Key="item02DF" Value="防風珠【２】"/>
+        <handlers:Item Key="item02E0" Value="耐震珠【２】"/>
+        <handlers:Item Key="item02E1" Value="Fertilizer Jewel 1"/>
+        <handlers:Item Key="item02E2" Value="Heat Resist Jewel 2"/>
+        <handlers:Item Key="item02E3" Value="攻撃珠【１】"/>
+        <handlers:Item Key="item02E4" Value="防御珠【１】"/>
+        <handlers:Item Key="item02E5" Value="体力珠【１】"/>
+        <handlers:Item Key="item02E6" Value="早復珠【１】"/>
+        <handlers:Item Key="item02E7" Value="耐火珠【１】"/>
+        <handlers:Item Key="item02E8" Value="耐水珠【１】"/>
+        <handlers:Item Key="item02E9" Value="耐氷珠【１】"/>
+        <handlers:Item Key="item02EA" Value="耐雷珠【１】"/>
+        <handlers:Item Key="item02EB" Value="耐龍珠【１】"/>
+        <handlers:Item Key="item02EC" Value="耐属珠【１】"/>
+        <handlers:Item Key="item02ED" Value="火炎珠【１】"/>
+        <handlers:Item Key="item02EE" Value="流水珠【１】"/>
+        <handlers:Item Key="item02EF" Value="氷結珠【１】"/>
+        <handlers:Item Key="item02F0" Value="雷光珠【１】"/>
+        <handlers:Item Key="item02F1" Value="破龍珠【１】"/>
+        <handlers:Item Key="item02F2" Value="毒珠【１】"/>
+        <handlers:Item Key="item02F3" Value="麻痺珠【１】"/>
+        <handlers:Item Key="item02F4" Value="睡眠珠【１】"/>
+        <handlers:Item Key="item02F5" Value="爆破珠【１】"/>
+        <handlers:Item Key="item02F6" Value="毒瓶珠【３】"/>
+        <handlers:Item Key="item02F7" Value="痺瓶珠【３】"/>
+        <handlers:Item Key="item02F8" Value="眠瓶珠【３】"/>
+        <handlers:Item Key="item02F9" Value="爆瓶珠【３】"/>
+        <handlers:Item Key="item02FA" Value="Powercoat Jewel 3"/>
+        <handlers:Item Key="item02FB" Value="解放珠【３】"/>
+        <handlers:Item Key="item02FC" Value="達人珠【１】"/>
+        <handlers:Item Key="item02FD" Value="超心珠【２】"/>
+        <handlers:Item Key="item02FE" Value="痛撃珠【２】"/>
+        <handlers:Item Key="item02FF" Value="短縮珠【２】"/>
+        <handlers:Item Key="item0300" Value="匠珠【３】"/>
+        <handlers:Item Key="item0301" Value="抜刀珠【２】"/>
+        <handlers:Item Key="item0302" Value="重撃珠【２】"/>
+        <handlers:Item Key="item0303" Value="ＫＯ珠【２】"/>
+        <handlers:Item Key="item0304" Value="奪気珠【１】"/>
+        <handlers:Item Key="item0305" Value="Rodeo Jewel 2"/>
+        <handlers:Item Key="item0306" Value="飛燕珠【２】"/>
+        <handlers:Item Key="item0307" Value="全開珠【２】"/>
+        <handlers:Item Key="item0308" Value="挑戦珠【２】"/>
+        <handlers:Item Key="item0309" Value="無傷珠【２】"/>
+        <handlers:Item Key="item030A" Value="底力珠【２】"/>
+        <handlers:Item Key="item030B" Value="逆境珠【１】"/>
+        <handlers:Item Key="item030C" Value="逆上珠【２】"/>
+        <handlers:Item Key="item030D" Value="鼓笛珠【１】"/>
+        <handlers:Item Key="item030E" Value="増弾珠【２】"/>
+        <handlers:Item Key="item030F" Value="特射珠【１】"/>
+        <handlers:Item Key="item0310" Value="砲術珠【１】"/>
+        <handlers:Item Key="item0311" Value="砲手珠【１】"/>
+        <handlers:Item Key="item0312" Value="強走珠【２】"/>
+        <handlers:Item Key="item0313" Value="体術珠【２】"/>
+        <handlers:Item Key="item0314" Value="Flying Leap Jewel 1"/>
+        <handlers:Item Key="item0315" Value="早気珠【２】"/>
+        <handlers:Item Key="item0316" Value="無食珠【１】"/>
+        <handlers:Item Key="item0317" Value="回避珠【２】"/>
+        <handlers:Item Key="item0318" Value="跳躍珠【２】"/>
+        <handlers:Item Key="item0319" Value="鉄壁珠【１】"/>
+        <handlers:Item Key="item031A" Value="速納珠【１】"/>
+        <handlers:Item Key="item031B" Value="友愛珠【１】"/>
+        <handlers:Item Key="item031C" Value="持続珠【１】"/>
+        <handlers:Item Key="item031D" Value="節食珠【１】"/>
+        <handlers:Item Key="item031E" Value="早食珠【１】"/>
+        <handlers:Item Key="item031F" Value="研磨珠【１】"/>
+        <handlers:Item Key="item0320" Value="爆師珠【１】"/>
+        <handlers:Item Key="item0321" Value="茸好珠【１】"/>
+        <handlers:Item Key="item0322" Value="Angler Jewel 1"/>
+        <handlers:Item Key="item0323" Value="Chef Jewel 1"/>
+        <handlers:Item Key="item0324" Value="Transporter Jewel 1"/>
+        <handlers:Item Key="item0325" Value="Gathering Jewel 1"/>
+        <handlers:Item Key="item0326" Value="Honeybee Jewel 1"/>
+        <handlers:Item Key="item0327" Value="Carver Jewel 1"/>
+        <handlers:Item Key="item0328" Value="加護珠【１】"/>
+        <handlers:Item Key="item0329" Value="采配珠【１】"/>
+        <handlers:Item Key="item032A" Value="植学珠【１】"/>
+        <handlers:Item Key="item032B" Value="地学珠【１】"/>
+        <handlers:Item Key="item032C" Value="渾身珠【２】"/>
+        <handlers:Item Key="item032D" Value="投石珠【１】"/>
+        <handlers:Item Key="item032E" Value="潜伏珠【１】"/>
+        <handlers:Item Key="item032F" Value="耐衝珠【３】"/>
+        <handlers:Item Key="item0330" Value="Scoutfly Jewel 1"/>
+        <handlers:Item Key="item0331" Value="Crouching Jewel 1"/>
+        <handlers:Item Key="item0332" Value="Longjump Jewel 1"/>
+        <handlers:Item Key="item0333" Value="煙復珠【１】"/>
+        <handlers:Item Key="item0334" Value="沼渡珠【１】"/>
+        <handlers:Item Key="item0335" Value="Climber Jewel 1"/>
+        <handlers:Item Key="item0336" Value="Radiosity Jewel 1"/>
+        <handlers:Item Key="item0337" Value="Research Jewel 1"/>
+        <handlers:Item Key="item0338" Value="標本珠【１】"/>
+        <handlers:Item Key="item0339" Value="耐瘴珠【１】"/>
+        <handlers:Item Key="item033A" Value="嗅覚珠【１】"/>
+        <handlers:Item Key="item033B" Value="Slider Jewel 1"/>
+        <handlers:Item Key="item033C" Value="威嚇珠【１】"/>
+        <handlers:Item Key="item033D" Value="Hazmat Jewel 1"/>
+        <handlers:Item Key="item033E" Value="Mudshield Jewel 1"/>
+        <handlers:Item Key="item033F" Value="Element Resist Jewel 1"/>
+        <handlers:Item Key="item0340" Value="滑走珠【２】"/>
+        <handlers:Item Key="item0341" Value="治癒珠【１】"/>
+        <handlers:Item Key="item0342" Value="強弾珠【３】"/>
+        <handlers:Item Key="item0343" Value="貫通珠【３】"/>
+        <handlers:Item Key="item0344" Value="散弾珠【３】"/>
+        <handlers:Item Key="item0345" Value="昂揚珠【２】"/>
+        <handlers:Item Key="item0346" Value="窮地珠【１】"/>
+        <handlers:Item Key="item0347" Value="龍封珠【３】"/>
+        <handlers:Item Key="item0348" Value="Discovery Jewel 2"/>
+        <handlers:Item Key="item0349" Value="Detector Jewel 1"/>
+        <handlers:Item Key="item034A" Value="整備珠【１】"/>
+        <handlers:Item Key="item034B" Value="ミツムシお届けの指笛"/>
+        <handlers:Item Key="item034C" Value="ミツムシ設置の指笛"/>
+        <handlers:Item Key="item034D" Value="閃光虫かごの指笛"/>
+        <handlers:Item Key="item034E" Value="痺れ虫かごの指笛"/>
+        <handlers:Item Key="item034F" Value="大盾挑発の指笛"/>
+        <handlers:Item Key="item0350" Value="大盾バッシュの指笛"/>
+        <handlers:Item Key="item0351" Value="はげましホルンの指笛"/>
+        <handlers:Item Key="item0352" Value="はげましボンゴの指笛"/>
+        <handlers:Item Key="item0353" Value="ぶんどり突撃の指笛"/>
+        <handlers:Item Key="item0354" Value="落っことし投擲の指笛"/>
+        <handlers:Item Key="item0355" Value="壺爆弾投擲の指笛"/>
+        <handlers:Item Key="item0356" Value="火炎車の指笛"/>
+        <handlers:Item Key="item0357" Value="Item 855"/>
+        <handlers:Item Key="item0358" Value="Item 856"/>
+        <handlers:Item Key="item0359" Value="Item 857"/>
+        <handlers:Item Key="item035A" Value="Item 858"/>
+        <handlers:Item Key="item035B" Value="石ころ"/>
+        <handlers:Item Key="item035C" Value="ツブテの実"/>
+        <handlers:Item Key="item035D" Value="ヒカリゴケ"/>
+        <handlers:Item Key="item035E" Value="はじけクルミ"/>
+        <handlers:Item Key="item035F" Value="スリンガー松明弾"/>
+        <handlers:Item Key="item0360" Value="スリンガー爆発弾"/>
+        <handlers:Item Key="item0361" Value="スリンガー着撃弾"/>
+        <handlers:Item Key="item0362" Value="スリンガー貫通弾"/>
+        <handlers:Item Key="item0363" Value="スリンガー滅龍弾"/>
+        <handlers:Item Key="item0364" Value="ハジケ結晶"/>
+        <handlers:Item Key="item0365" Value="スリンガー水流弾"/>
+        <handlers:Item Key="item0366" Value="ヒンヤリダケ"/>
+        <handlers:Item Key="item0367" Value="オトモダチケット"/>
+        <handlers:Item Key="item0368" Value="エメラルドな殻"/>
+        <handlers:Item Key="item0369" Value="奇面族スケッチ"/>
+        <handlers:Item Key="item036A" Value="強弓珠【２】"/>
+        <handlers:Item Key="item036B" Value="心眼珠【２】"/>
+        <handlers:Item Key="item036C" Value="強壁珠【２】"/>
+        <handlers:Item Key="item036D" Value="剛刃珠【２】"/>
+        <handlers:Item Key="item036E" Value="無撃珠【２】"/>
+        <handlers:Item Key="item036F" Value="恐暴竜の黒鱗"/>
+        <handlers:Item Key="item0370" Value="恐暴竜の黒皮"/>
+        <handlers:Item Key="item0371" Value="恐暴竜の大牙"/>
+        <handlers:Item Key="item0372" Value="恐暴竜の鉤爪"/>
+        <handlers:Item Key="item0373" Value="恐暴竜の頭殻"/>
+        <handlers:Item Key="item0374" Value="恐暴竜の尻尾"/>
+        <handlers:Item Key="item0375" Value="恐暴竜の唾液"/>
+        <handlers:Item Key="item0376" Value="恐暴竜の宝玉"/>
+        <handlers:Item Key="item0377" Value="爛輝龍の金鱗"/>
+        <handlers:Item Key="item0378" Value="爛輝龍の金殻"/>
+        <handlers:Item Key="item0379" Value="爛輝龍の金塊"/>
+        <handlers:Item Key="item037A" Value="爛輝龍の金巻角"/>
+        <handlers:Item Key="item037B" Value="爛輝龍の金尾殻"/>
+        <handlers:Item Key="item037C" Value="爛輝龍の金煌玉"/>
+        <handlers:Item Key="item037D" Value="黄金石のかけら"/>
+        <handlers:Item Key="item037E" Value="黄金石の塊"/>
+        <handlers:Item Key="item037F" Value="炎妃龍の上鱗"/>
+        <handlers:Item Key="item0380" Value="炎妃龍の翼"/>
+        <handlers:Item Key="item0381" Value="炎妃龍の宝玉"/>
+        <handlers:Item Key="item0382" Value="炎妃龍の堅殻"/>
+        <handlers:Item Key="item0383" Value="炎妃龍のたてがみ"/>
+        <handlers:Item Key="item0384" Value="炎妃龍の尻尾"/>
+        <handlers:Item Key="item0385" Value="炎妃龍の尖角"/>
+        <handlers:Item Key="item0386" Value="魔獣のたてがみ"/>
+        <handlers:Item Key="item0387" Value="魔獣の堅骨"/>
+        <handlers:Item Key="item0388" Value="魔獣の大角"/>
+        <handlers:Item Key="item0389" Value="魔獣の裂爪"/>
+        <handlers:Item Key="item038A" Value="魔獣の尻尾"/>
+        <handlers:Item Key="item038B" Value="エーテライトの欠片"/>
+        <handlers:Item Key="item038C" Value="開花チケット"/>
+        <handlers:Item Key="item038D" Value="納涼チケット"/>
+        <handlers:Item Key="item038E" Value="豊穣チケット"/>
+        <handlers:Item Key="item038F" Value="煌めきチケット"/>
+        <handlers:Item Key="item0390" Value="感謝チケット"/>
+        <handlers:Item Key="item0391" Value="昆虫図鑑【春】"/>
+        <handlers:Item Key="item0392" Value="昆虫図鑑【夏】"/>
+        <handlers:Item Key="item0393" Value="屍套龍チケット"/>
+        <handlers:Item Key="item0394" Value="幻獣チケット"/>
+        <handlers:Item Key="item0395" Value="炎王龍チケット"/>
+        <handlers:Item Key="item0396" Value="鋼龍チケット"/>
+        <handlers:Item Key="item0397" Value="滅尽龍チケット"/>
+        <handlers:Item Key="item0398" Value="熔山龍チケット"/>
+        <handlers:Item Key="item0399" Value="冥灯龍チケット"/>
+        <handlers:Item Key="item039A" Value="黒い包帯"/>
+        <handlers:Item Key="item039B" Value="黒い水晶チケット"/>
+        <handlers:Item Key="item039C" Value="掻鳥チケット"/>
+        <handlers:Item Key="item039D" Value="ユラユラチケット"/>
+        <handlers:Item Key="item039E" Value="Item 926"/>
+        <handlers:Item Key="item039F" Value="Item 927"/>
+        <handlers:Item Key="item03A0" Value="ロックマンチケット"/>
+        <handlers:Item Key="item03A1" Value="Item 929"/>
+        <handlers:Item Key="item03A2" Value="Item 930"/>
+        <handlers:Item Key="item03A3" Value="Item 931"/>
+        <handlers:Item Key="item03A4" Value="蒼星のかけら"/>
+        <handlers:Item Key="item03A5" Value="蒼星の宝玉"/>
+        <handlers:Item Key="item03A6" Value="レッドオーブ"/>
+        <handlers:Item Key="item03A7" Value="名匠の設計図"/>
+        <handlers:Item Key="item03A8" Value="溶解した武器"/>
+        <handlers:Item Key="item03A9" Value="結合された武器"/>
+        <handlers:Item Key="item03AA" Value="昇華された武器"/>
+        <handlers:Item Key="item03AB" Value="暁ノ武士チケット"/>
+        <handlers:Item Key="item03AC" Value="打上花火【開花】"/>
+        <handlers:Item Key="item03AD" Value="打上花火【納涼】"/>
+        <handlers:Item Key="item03AE" Value="噴出花火【豊穣】"/>
+        <handlers:Item Key="item03AF" Value="打上花火【煌めき】"/>
+        <handlers:Item Key="item03B0" Value="打上花火【感謝】"/>
+        <handlers:Item Key="item03B1" Value="コンジキウロコウモリ"/>
+        <handlers:Item Key="item03B2" Value="キンパクカブトガニ"/>
+        <handlers:Item Key="item03B3" Value="ジュンキンカブトガニ"/>
+        <handlers:Item Key="item03B4" Value="カッパーカラッパ"/>
+        <handlers:Item Key="item03B5" Value="ゴールドカラッパ"/>
+        <handlers:Item Key="item03B6" Value="ツチノコ"/>
+        <handlers:Item Key="item03B7" Value="ミニテンダー"/>
+        <handlers:Item Key="item03B8" Value="黄金片のかけら"/>
+        <handlers:Item Key="item03B9" Value="黄金片の塊"/>
+        <handlers:Item Key="item03BA" Value="ブロッサムチケット"/>
+        <handlers:Item Key="item03BB" Value="セヌの風切り羽"/>
+        <handlers:Item Key="item03BC" Value="イグニの印"/>
+        <handlers:Item Key="item03BD" Value="ハンターのルーン石"/>
+        <handlers:Item Key="item03BE" Value="ネッカー"/>
+        <handlers:Item Key="item03BF" Value="ブリゲイドチケット"/>
+        <handlers:Item Key="item03C0" Value="ギルドクロスチケット"/>
+        <handlers:Item Key="item03C1" Value="フワフワチケット"/>
+        <handlers:Item Key="item03C2" Value="ゴワゴワチケット"/>
+        <handlers:Item Key="item03C3" Value="１期団チケット"/>
+        <handlers:Item Key="item03C4" Value="５期団チケット"/>
+        <handlers:Item Key="item03C5" Value="炎妃龍チケット"/>
+        <handlers:Item Key="item03C6" Value="透明な石"/>
+        <handlers:Item Key="item03C7" Value="ミニフラワーテンダー"/>
+        <handlers:Item Key="item03C8" Value="サボテンダー"/>
+        <handlers:Item Key="item03C9" Value="フェイクチケット"/>
+        <handlers:Item Key="item03CA" Value="フェイクチケットⅡ"/>
+        <handlers:Item Key="item03CB" Value="フェイクチケットⅢ"/>
+        <handlers:Item Key="item03CC" Value="ビートルチケット"/>
+        <handlers:Item Key="item03CD" Value="Item 973"/>
+        <handlers:Item Key="item03CE" Value="Item 974"/>
+        <handlers:Item Key="item03CF" Value="ミラージュプリズム"/>
+        <handlers:Item Key="item03D0" Value="Item 976"/>
+        <handlers:Item Key="item03D1" Value="灼熱を帯びた武器"/>
+        <handlers:Item Key="item03D2" Value="爛輝龍の皇金塊"/>
+        <handlers:Item Key="item03D3" Value="レーシェンの木爪"/>
+        <handlers:Item Key="item03D4" Value="レーシェンの樹爪"/>
+        <handlers:Item Key="item03D5" Value="レーシェン討伐の証"/>
+        <handlers:Item Key="item03D6" Value="古のレーシェン討伐の証"/>
+        <handlers:Item Key="item03D7" Value="怪物の呪骨"/>
+        <handlers:Item Key="item03D8" Value="怪物の古呪骨"/>
+        <handlers:Item Key="item03D9" Value="レーシェンの呪角"/>
+        <handlers:Item Key="item03DA" Value="レーシェンの古呪角"/>
+        <handlers:Item Key="item03DB" Value="レーシェンの樹脂"/>
+        <handlers:Item Key="item03DC" Value="変異誘発剤"/>
+        <handlers:Item Key="item03DD" Value="ネッカーカード（攻）"/>
+        <handlers:Item Key="item03DE" Value="ネッカーカード（守）"/>
+        <handlers:Item Key="item03DF" Value="Item 991"/>
+        <handlers:Item Key="item03E0" Value="Item 992"/>
+        <handlers:Item Key="item03E1" Value="Item 993"/>
+        <handlers:Item Key="item03E2" Value="Item 994"/>
+        <handlers:Item Key="item03E3" Value="Item 995"/>
+        <handlers:Item Key="item03E4" Value="Item 996"/>
+        <handlers:Item Key="item03E5" Value="Item 997"/>
+        <handlers:Item Key="item03E6" Value="Item 998"/>
+        <handlers:Item Key="item03E7" Value="アサシンの装衣"/>
+        <handlers:Item Key="item03E8" Value="ホットドリンク"/>
+        <handlers:Item Key="item03E9" Value="Item 1001"/>
+        <handlers:Item Key="item03EA" Value="Item 1002"/>
+        <handlers:Item Key="item03EB" Value="Gourmet Voucher"/>
+        <handlers:Item Key="item03EC" Value="観察キット"/>
+        <handlers:Item Key="item03ED" Value="Raider Ride"/>
+        <handlers:Item Key="item03EE" Value="とうがらし"/>
+        <handlers:Item Key="item03EF" Value="Gloamgrass Bud"/>
+        <handlers:Item Key="item03F0" Value="Dust of Life"/>
+        <handlers:Item Key="item03F1" Value="Crystalized Bone Shard"/>
+        <handlers:Item Key="item03F2" Value="Crystalized Monster Bone"/>
+        <handlers:Item Key="item03F3" Value="Crystalized Elder Dragon Bone"/>
+        <handlers:Item Key="item03F4" Value="Item 1012"/>
+        <handlers:Item Key="item03F5" Value="Item 1013"/>
+        <handlers:Item Key="item03F6" Value="Item 1014"/>
+        <handlers:Item Key="item03F7" Value="Item 1015"/>
+        <handlers:Item Key="item03F8" Value="Item 1016"/>
+        <handlers:Item Key="item03F9" Value="Item 1017"/>
+        <handlers:Item Key="item03FA" Value="Item 1018"/>
+        <handlers:Item Key="item03FB" Value="Item 1019"/>
+        <handlers:Item Key="item03FC" Value="Item 1020"/>
+        <handlers:Item Key="item03FD" Value="Item 1021"/>
+        <handlers:Item Key="item03FE" Value="Vigorwasp Revival"/>
+        <handlers:Item Key="item03FF" Value="Boombug Cage"/>
+        <handlers:Item Key="item0400" Value="Shieldspire Stooge"/>
+        <handlers:Item Key="item0401" Value="Coral Sonicgong"/>
+        <handlers:Item Key="item0402" Value="Mount &amp; Plunder"/>
+        <handlers:Item Key="item0403" Value="Meowcano"/>
+        <handlers:Item Key="item0404" Value="zenny"/>
+        <handlers:Item Key="item0405" Value="Research Points"/>
+        <handlers:Item Key="item0406" Value="Eltalite Ore"/>
+        <handlers:Item Key="item0407" Value="Meldspar Ore"/>
+        <handlers:Item Key="item0408" Value="Spiritvein Crystal"/>
+        <handlers:Item Key="item0409" Value="Item 1033"/>
+        <handlers:Item Key="item040A" Value="Purecrystal"/>
+        <handlers:Item Key="item040B" Value="Item 1035"/>
+        <handlers:Item Key="item040C" Value="Bathycite Ore"/>
+        <handlers:Item Key="item040D" Value="Gracium"/>
+        <handlers:Item Key="item040E" Value="Phantomcore Ore"/>
+        <handlers:Item Key="item040F" Value="Shadowcore Ore"/>
+        <handlers:Item Key="item0410" Value="King Armor Sphere"/>
+        <handlers:Item Key="item0411" Value="True Armor Sphere"/>
+        <handlers:Item Key="item0412" Value="Thick Bone"/>
+        <handlers:Item Key="item0413" Value="Frozen Bone"/>
+        <handlers:Item Key="item0414" Value="Dragonbone Artifact"/>
+        <handlers:Item Key="item0415" Value="Item 1045"/>
+        <handlers:Item Key="item0416" Value="Item 1046"/>
+        <handlers:Item Key="item0417" Value="Item 1047"/>
+        <handlers:Item Key="item0418" Value="Ancient Fragment"/>
+        <handlers:Item Key="item0419" Value="Monster Toughbone"/>
+        <handlers:Item Key="item041A" Value="Monster Slogbone"/>
+        <handlers:Item Key="item041B" Value="Monster Solidbone"/>
+        <handlers:Item Key="item041C" Value="Item 1052"/>
+        <handlers:Item Key="item041D" Value="Large Elder Dragon Bone"/>
+        <handlers:Item Key="item041E" Value="Tough Claw"/>
+        <handlers:Item Key="item041F" Value="Monster Essence"/>
+        <handlers:Item Key="item0420" Value="Deadly Poison Sac"/>
+        <handlers:Item Key="item0421" Value="Ultraplegia Sac"/>
+        <handlers:Item Key="item0422" Value="Torpor Sac"/>
+        <handlers:Item Key="item0423" Value="Conflagrant Sac"/>
+        <handlers:Item Key="item0424" Value="Flood Sac"/>
+        <handlers:Item Key="item0425" Value="Cryo Sac"/>
+        <handlers:Item Key="item0426" Value="Lightning Sac"/>
+        <handlers:Item Key="item0427" Value="Fey Wyvern Gem"/>
+        <handlers:Item Key="item0428" Value="Large Wyvern Gem"/>
+        <handlers:Item Key="item0429" Value="Pure Dragon Blood"/>
+        <handlers:Item Key="item042A" Value="Large Elder Dragon Gem"/>
+        <handlers:Item Key="item042B" Value="Item 1067"/>
+        <handlers:Item Key="item042C" Value="Prized Pelt"/>
+        <handlers:Item Key="item042D" Value="Anteka Antler"/>
+        <handlers:Item Key="item042E" Value="Item 1070"/>
+        <handlers:Item Key="item042F" Value="Vespoid Razorwing"/>
+        <handlers:Item Key="item0430" Value="Item 1072"/>
+        <handlers:Item Key="item0431" Value="Hornetaur Razorwing"/>
+        <handlers:Item Key="item0432" Value="Item 1074"/>
+        <handlers:Item Key="item0433" Value="Gajau Thickhide"/>
+        <handlers:Item Key="item0434" Value="Steel Gajau Whisker"/>
+        <handlers:Item Key="item0435" Value="Wingdrake Finehide"/>
+        <handlers:Item Key="item0436" Value="Barnos Hardclaw"/>
+        <handlers:Item Key="item0437" Value="Item 1079"/>
+        <handlers:Item Key="item0438" Value="Cortos Hardclaw"/>
+        <handlers:Item Key="item0439" Value="Kestodon Husk"/>
+        <handlers:Item Key="item043A" Value="Item 1082"/>
+        <handlers:Item Key="item043B" Value="Gastodon Husk"/>
+        <handlers:Item Key="item043C" Value="Item 1084"/>
+        <handlers:Item Key="item043D" Value="Jagras Shard"/>
+        <handlers:Item Key="item043E" Value="Item 1086"/>
+        <handlers:Item Key="item043F" Value="Shamos Shard"/>
+        <handlers:Item Key="item0440" Value="Item 1088"/>
+        <handlers:Item Key="item0441" Value="Girros Shard"/>
+        <handlers:Item Key="item0442" Value="Item 1090"/>
+        <handlers:Item Key="item0443" Value="Wulg Thickfur"/>
+        <handlers:Item Key="item0444" Value="Item 1092"/>
+        <handlers:Item Key="item0445" Value="Great Jagras Shard"/>
+        <handlers:Item Key="item0446" Value="Great Jagras Thickhide"/>
+        <handlers:Item Key="item0447" Value="Great Jagras Hardclaw"/>
+        <handlers:Item Key="item0448" Value="Great Jagras Mane+"/>
+        <handlers:Item Key="item0449" Value="Kulu-Ya-Ku Shard"/>
+        <handlers:Item Key="item044A" Value="Kulu-Ya-Ku Thickhide"/>
+        <handlers:Item Key="item044B" Value="Large Kulu-Ya-Ku Plume"/>
+        <handlers:Item Key="item044C" Value="Large Kulu-Ya-Ku Beak"/>
+        <handlers:Item Key="item044D" Value="Pukei-Pukei Shard"/>
+        <handlers:Item Key="item044E" Value="Pukei-Pukei Cortex"/>
+        <handlers:Item Key="item044F" Value="Pukei-Pukei Fellwing"/>
+        <handlers:Item Key="item0450" Value="Large Pukei-Pukei Sac"/>
+        <handlers:Item Key="item0451" Value="Pukei-Pukei Lash"/>
+        <handlers:Item Key="item0452" Value="Coral Pukei-Pukei Shard"/>
+        <handlers:Item Key="item0453" Value="Coral Pukei-Pukei Cortex"/>
+        <handlers:Item Key="item0454" Value="Coral Pukei-Pukei Fellwing"/>
+        <handlers:Item Key="item0455" Value="Large Coral Pukei-Pukei Sac"/>
+        <handlers:Item Key="item0456" Value="Coral Pukei-Pukei Lash"/>
+        <handlers:Item Key="item0457" Value="Barroth Cortex"/>
+        <handlers:Item Key="item0458" Value="Barroth Chine"/>
+        <handlers:Item Key="item0459" Value="Barroth Hardclaw"/>
+        <handlers:Item Key="item045A" Value="Barroth Crown"/>
+        <handlers:Item Key="item045B" Value="Barroth Lash"/>
+        <handlers:Item Key="item045C" Value="Rich Mud"/>
+        <handlers:Item Key="item045D" Value="Jyuratodus Shard"/>
+        <handlers:Item Key="item045E" Value="Jyuratodus Cortex"/>
+        <handlers:Item Key="item045F" Value="Jyuratodus Hardfang"/>
+        <handlers:Item Key="item0460" Value="Jyuratodus Grandfin"/>
+        <handlers:Item Key="item0461" Value="Beotodus Shard"/>
+        <handlers:Item Key="item0462" Value="Beotodus Cortex"/>
+        <handlers:Item Key="item0463" Value="Beotodus Hardhorn"/>
+        <handlers:Item Key="item0464" Value="Beotodus Grandfin"/>
+        <handlers:Item Key="item0465" Value="Tobi-Kadachi Shard"/>
+        <handlers:Item Key="item0466" Value="Tobi-Kadachi Thickfur"/>
+        <handlers:Item Key="item0467" Value="Tobi-Kadachi Membrane+"/>
+        <handlers:Item Key="item0468" Value="Tobi-Kadachi Hardclaw"/>
+        <handlers:Item Key="item0469" Value="Tobi-Kadachi Cathode"/>
+        <handlers:Item Key="item046A" Value="Viper Tobi-Kadachi Shard"/>
+        <handlers:Item Key="item046B" Value="Viper Tobi-Kadachi Thickfur"/>
+        <handlers:Item Key="item046C" Value="Viper Tobi-Kadachi Membrane+"/>
+        <handlers:Item Key="item046D" Value="Viper Tobi-Kadachi Hardclaw"/>
+        <handlers:Item Key="item046E" Value="Viper Tobi-Kadachi Thorn"/>
+        <handlers:Item Key="item046F" Value="Banbaro Cortex"/>
+        <handlers:Item Key="item0470" Value="Banbaro Chine"/>
+        <handlers:Item Key="item0471" Value="Banbaro Great Horn"/>
+        <handlers:Item Key="item0472" Value="Banbaro Lash"/>
+        <handlers:Item Key="item0473" Value="Anjanath Shard"/>
+        <handlers:Item Key="item0474" Value="Anjanath Fur"/>
+        <handlers:Item Key="item0475" Value="Anjanath Hardfang"/>
+        <handlers:Item Key="item0476" Value="Heavy Anjanath Nosebone"/>
+        <handlers:Item Key="item0477" Value="Anjanath Lash"/>
+        <handlers:Item Key="item0478" Value="Anjanath Mantle"/>
+        <handlers:Item Key="item0479" Value="Fulgur Anjanath Shard"/>
+        <handlers:Item Key="item047A" Value="Fulgur Anjanath Thickfur"/>
+        <handlers:Item Key="item047B" Value="Fulgur Anjanath Hardfang"/>
+        <handlers:Item Key="item047C" Value="Heavy Fulgur Anjanath Nosebone"/>
+        <handlers:Item Key="item047D" Value="Fulgur Anjanath Lash"/>
+        <handlers:Item Key="item047E" Value="Fulgur Anjanath Mantle"/>
+        <handlers:Item Key="item047F" Value="Rathian Shard"/>
+        <handlers:Item Key="item0480" Value="Rathian Cortex"/>
+        <handlers:Item Key="item0481" Value="Rathian Weave"/>
+        <handlers:Item Key="item0482" Value="Rathian Surspike"/>
+        <handlers:Item Key="item0483" Value="Rathian Mantle"/>
+        <handlers:Item Key="item0484" Value="Pink Rathian Shard"/>
+        <handlers:Item Key="item0485" Value="Pink Rathian Cortex"/>
+        <handlers:Item Key="item0486" Value="Gold Rathian Shard"/>
+        <handlers:Item Key="item0487" Value="Gold Rathian Cortex"/>
+        <handlers:Item Key="item0488" Value="Gold Rathian Surspike"/>
+        <handlers:Item Key="item0489" Value="Tzitzi-Ya-Ku Shard"/>
+        <handlers:Item Key="item048A" Value="Tzitzi-Ya-Ku Thickhide"/>
+        <handlers:Item Key="item048B" Value="Tzitzi-Ya-Ku Hardclaw"/>
+        <handlers:Item Key="item048C" Value="Tzitzi-Ya-Ku Photomembrane"/>
+        <handlers:Item Key="item048D" Value="Paolumu Thickfur"/>
+        <handlers:Item Key="item048E" Value="Paolumu Shard"/>
+        <handlers:Item Key="item048F" Value="Paolumu Cortex"/>
+        <handlers:Item Key="item0490" Value="Paolumu Fellwing"/>
+        <handlers:Item Key="item0491" Value="Nightshade Paolumu Thickfur"/>
+        <handlers:Item Key="item0492" Value="Nightshade Paolumu Shard"/>
+        <handlers:Item Key="item0493" Value="Nightshade Paolumu Fellwing"/>
+        <handlers:Item Key="item0494" Value="Great Girros Shard"/>
+        <handlers:Item Key="item0495" Value="Great Girros Thickhide"/>
+        <handlers:Item Key="item0496" Value="Great Girros Hardhood"/>
+        <handlers:Item Key="item0497" Value="Great Girros Hardfang"/>
+        <handlers:Item Key="item0498" Value="Great Girros Lash"/>
+        <handlers:Item Key="item0499" Value="Radobaan Shard"/>
+        <handlers:Item Key="item049A" Value="Radobaan Cortex"/>
+        <handlers:Item Key="item049B" Value="Radobaan Oilshell+"/>
+        <handlers:Item Key="item049C" Value="Large Wyvern Bonemass"/>
+        <handlers:Item Key="item049D" Value="Legiana Shard"/>
+        <handlers:Item Key="item049E" Value="Legiana Thickhide"/>
+        <handlers:Item Key="item049F" Value="Legiana Hardclaw"/>
+        <handlers:Item Key="item04A0" Value="Legiana Fellwing"/>
+        <handlers:Item Key="item04A1" Value="Legiana Tail Webbing+"/>
+        <handlers:Item Key="item04A2" Value="Legiana Mantle"/>
+        <handlers:Item Key="item04A3" Value="Item 1187"/>
+        <handlers:Item Key="item04A4" Value="Rimed Hide"/>
+        <handlers:Item Key="item04A5" Value="Obsidian Icetalon"/>
+        <handlers:Item Key="item04A6" Value="Stark Wing"/>
+        <handlers:Item Key="item04A7" Value="Item 1191"/>
+        <handlers:Item Key="item04A8" Value="Item 1192"/>
+        <handlers:Item Key="item04A9" Value="Odogaron Shard"/>
+        <handlers:Item Key="item04AA" Value="Hard Odogaron Sinew"/>
+        <handlers:Item Key="item04AB" Value="Odogaron Hardclaw"/>
+        <handlers:Item Key="item04AC" Value="Odogaron Hardfang"/>
+        <handlers:Item Key="item04AD" Value="Odogaron Lash"/>
+        <handlers:Item Key="item04AE" Value="Odogaron Mantle"/>
+        <handlers:Item Key="item04AF" Value="Ebony Odogaron Shard"/>
+        <handlers:Item Key="item04B0" Value="Hard Ebony Odogaron Sinew"/>
+        <handlers:Item Key="item04B1" Value="Ebony Odogaron Hardclaw"/>
+        <handlers:Item Key="item04B2" Value="Ebony Odogaron Hardfang"/>
+        <handlers:Item Key="item04B3" Value="Ebony Odogaron Lash"/>
+        <handlers:Item Key="item04B4" Value="Ebony Odogaron Mantle"/>
+        <handlers:Item Key="item04B5" Value="Rathalos Shard"/>
+        <handlers:Item Key="item04B6" Value="Rathalos Cortex"/>
+        <handlers:Item Key="item04B7" Value="Rathalos Fellwing"/>
+        <handlers:Item Key="item04B8" Value="Rathalos Lash"/>
+        <handlers:Item Key="item04B9" Value="Rath Wingtalon+"/>
+        <handlers:Item Key="item04BA" Value="Rathalos Mantle"/>
+        <handlers:Item Key="item04BB" Value="Azure Rathalos Shard"/>
+        <handlers:Item Key="item04BC" Value="Azure Rathalos Cortex"/>
+        <handlers:Item Key="item04BD" Value="Azure Rathalos Lash"/>
+        <handlers:Item Key="item04BE" Value="Azure Rathalos Fellwing"/>
+        <handlers:Item Key="item04BF" Value="Silver Rathalos Shard"/>
+        <handlers:Item Key="item04C0" Value="Silver Rathalos Cortex"/>
+        <handlers:Item Key="item04C1" Value="Silver Rathalos Fellwing"/>
+        <handlers:Item Key="item04C2" Value="Silver Rathalos Lash"/>
+        <handlers:Item Key="item04C3" Value="Rath Gleam"/>
+        <handlers:Item Key="item04C4" Value="Diablos Cortex"/>
+        <handlers:Item Key="item04C5" Value="Diablos Chine"/>
+        <handlers:Item Key="item04C6" Value="Diablos Tailcase+"/>
+        <handlers:Item Key="item04C7" Value="Twisted Stouthorn"/>
+        <handlers:Item Key="item04C8" Value="Diablos Hardhorn"/>
+        <handlers:Item Key="item04C9" Value="Black Diablos Cortex"/>
+        <handlers:Item Key="item04CA" Value="Black Diablos Chine"/>
+        <handlers:Item Key="item04CB" Value="Blackcurl Stouthorn"/>
+        <handlers:Item Key="item04CC" Value="Dodogama Shard"/>
+        <handlers:Item Key="item04CD" Value="Dodogama Thickhide"/>
+        <handlers:Item Key="item04CE" Value="Dodogama Mandible"/>
+        <handlers:Item Key="item04CF" Value="Dodogama Hardclaw"/>
+        <handlers:Item Key="item04D0" Value="Dodogama Lash"/>
+        <handlers:Item Key="item04D1" Value="Lavasioth Shard"/>
+        <handlers:Item Key="item04D2" Value="Lavasioth Cortex"/>
+        <handlers:Item Key="item04D3" Value="Lavasioth Hardfang"/>
+        <handlers:Item Key="item04D4" Value="Lavasioth Grandfin"/>
+        <handlers:Item Key="item04D5" Value="Uragaan Shard"/>
+        <handlers:Item Key="item04D6" Value="Uragaan Cortex"/>
+        <handlers:Item Key="item04D7" Value="Uragaan Jaw+"/>
+        <handlers:Item Key="item04D8" Value="Uragaan Scute+"/>
+        <handlers:Item Key="item04D9" Value="Uragaan Pallium"/>
+        <handlers:Item Key="item04DA" Value="Barioth Cortex"/>
+        <handlers:Item Key="item04DB" Value="Barioth Thickfur"/>
+        <handlers:Item Key="item04DC" Value="Barioth Hardclaw"/>
+        <handlers:Item Key="item04DD" Value="Barioth Greatspike"/>
+        <handlers:Item Key="item04DE" Value="Barioth Lash"/>
+        <handlers:Item Key="item04DF" Value="Amber Hardfang"/>
+        <handlers:Item Key="item04E0" Value="Nargacuga Shard"/>
+        <handlers:Item Key="item04E1" Value="Nargacuga Blackfur+"/>
+        <handlers:Item Key="item04E2" Value="Nargacuga Lash"/>
+        <handlers:Item Key="item04E3" Value="Nargacuga Tailspear"/>
+        <handlers:Item Key="item04E4" Value="Nargacuga Cutwing+"/>
+        <handlers:Item Key="item04E5" Value="Nargacuga Hardfang"/>
+        <handlers:Item Key="item04E6" Value="Nargacuga Mantle"/>
+        <handlers:Item Key="item04E7" Value="Tigrex Shard"/>
+        <handlers:Item Key="item04E8" Value="Tigrex Cortex"/>
+        <handlers:Item Key="item04E9" Value="Tigrex Lash"/>
+        <handlers:Item Key="item04EA" Value="Tigrex Hardclaw"/>
+        <handlers:Item Key="item04EB" Value="Tigrex Hardfang"/>
+        <handlers:Item Key="item04EC" Value="Tigrex Mantle"/>
+        <handlers:Item Key="item04ED" Value="Brute Tigrex Shard"/>
+        <handlers:Item Key="item04EE" Value="Brute Tigrex Cortex"/>
+        <handlers:Item Key="item04EF" Value="Brute Tigrex Hardclaw"/>
+        <handlers:Item Key="item04F0" Value="Brute Tigrex Hardfang"/>
+        <handlers:Item Key="item04F1" Value="Glavenus Shard"/>
+        <handlers:Item Key="item04F2" Value="Glavenus Cortex"/>
+        <handlers:Item Key="item04F3" Value="Glavenus Hardfang"/>
+        <handlers:Item Key="item04F4" Value="Glavenus Hellshell"/>
+        <handlers:Item Key="item04F5" Value="Glavenus Tailedge"/>
+        <handlers:Item Key="item04F6" Value="Molten Bursa"/>
+        <handlers:Item Key="item04F7" Value="Glavenus Mantle"/>
+        <handlers:Item Key="item04F8" Value="Acidic Glavenus Shard"/>
+        <handlers:Item Key="item04F9" Value="Acidic Glavenus Cortex"/>
+        <handlers:Item Key="item04FA" Value="Acidic Glavenus Hardfang"/>
+        <handlers:Item Key="item04FB" Value="Acidic Glavenus Spineshell"/>
+        <handlers:Item Key="item04FC" Value="Acidic Glavenus Tailedge"/>
+        <handlers:Item Key="item04FD" Value="Honed Acidcryst"/>
+        <handlers:Item Key="item04FE" Value="Item 1278"/>
+        <handlers:Item Key="item04FF" Value="Brachydios Cortex"/>
+        <handlers:Item Key="item0500" Value="Fine Brachydios Ebonshell"/>
+        <handlers:Item Key="item0501" Value="Brachydios Crown"/>
+        <handlers:Item Key="item0502" Value="Glowing Slime"/>
+        <handlers:Item Key="item0503" Value="Brachydios Pounder+"/>
+        <handlers:Item Key="item0504" Value="Brachydios Lash"/>
+        <handlers:Item Key="item0505" Value="Brachydios Pallium"/>
+        <handlers:Item Key="item0506" Value="Item 1286"/>
+        <handlers:Item Key="item0507" Value="Item 1287"/>
+        <handlers:Item Key="item0508" Value="Item 1288"/>
+        <handlers:Item Key="item0509" Value="Item 1289"/>
+        <handlers:Item Key="item050A" Value="Garuga Shard"/>
+        <handlers:Item Key="item050B" Value="Garuga Cortex"/>
+        <handlers:Item Key="item050C" Value="Garuga Auricle"/>
+        <handlers:Item Key="item050D" Value="Fancy Beak"/>
+        <handlers:Item Key="item050E" Value="Garuga Fellwing"/>
+        <handlers:Item Key="item050F" Value="Garuga Lash"/>
+        <handlers:Item Key="item0510" Value="Garuga Silverpelt"/>
+        <handlers:Item Key="item0511" Value="Zinogre Cortex"/>
+        <handlers:Item Key="item0512" Value="Zinogre Electrofur+"/>
+        <handlers:Item Key="item0513" Value="Zinogre Hardhorn"/>
+        <handlers:Item Key="item0514" Value="Zinogre Hardclaw"/>
+        <handlers:Item Key="item0515" Value="Zinogre Lash"/>
+        <handlers:Item Key="item0516" Value="Zinogre Deathly Shocker"/>
+        <handlers:Item Key="item0517" Value="Fulgurbug"/>
+        <handlers:Item Key="item0518" Value="Zinogre Skymerald"/>
+        <handlers:Item Key="item0519" Value="Item 1305"/>
+        <handlers:Item Key="item051A" Value="Item 1306"/>
+        <handlers:Item Key="item051B" Value="Item 1307"/>
+        <handlers:Item Key="item051C" Value="Item 1308"/>
+        <handlers:Item Key="item051D" Value="Item 1309"/>
+        <handlers:Item Key="item051E" Value="Item 1310"/>
+        <handlers:Item Key="item051F" Value="Item 1311"/>
+        <handlers:Item Key="item0520" Value="Item 1312"/>
+        <handlers:Item Key="item0521" Value="Bazelgeuse Shard"/>
+        <handlers:Item Key="item0522" Value="Flickering Silvershell"/>
+        <handlers:Item Key="item0523" Value="Bazelgeuse Flail"/>
+        <handlers:Item Key="item0524" Value="Distilled Blast Fluid"/>
+        <handlers:Item Key="item0525" Value="Bazelgeuse Hardclaw"/>
+        <handlers:Item Key="item0526" Value="Scorching Silverwing"/>
+        <handlers:Item Key="item0527" Value="Bazelgeuse Mantle"/>
+        <handlers:Item Key="item0528" Value="Deviljho Shard"/>
+        <handlers:Item Key="item0529" Value="Deviljho Blackpiel"/>
+        <handlers:Item Key="item052A" Value="Item 1322"/>
+        <handlers:Item Key="item052B" Value="Vile Fang"/>
+        <handlers:Item Key="item052C" Value="Deviljho Ripper"/>
+        <handlers:Item Key="item052D" Value="Deviljho Flail"/>
+        <handlers:Item Key="item052E" Value="Black Blood"/>
+        <handlers:Item Key="item052F" Value="Deviljho Crook"/>
+        <handlers:Item Key="item0530" Value="Item 1328"/>
+        <handlers:Item Key="item0531" Value="Item 1329"/>
+        <handlers:Item Key="item0532" Value="Item 1330"/>
+        <handlers:Item Key="item0533" Value="Item 1331"/>
+        <handlers:Item Key="item0534" Value="Item 1332"/>
+        <handlers:Item Key="item0535" Value="Item 1333"/>
+        <handlers:Item Key="item0536" Value="Item 1334"/>
+        <handlers:Item Key="item0537" Value="Item 1335"/>
+        <handlers:Item Key="item0538" Value="Item 1336"/>
+        <handlers:Item Key="item0539" Value="Kirin Finehide"/>
+        <handlers:Item Key="item053A" Value="Kirin Thundertail+"/>
+        <handlers:Item Key="item053B" Value="Kirin Silvermane"/>
+        <handlers:Item Key="item053C" Value="Kirin Azure Horn+"/>
+        <handlers:Item Key="item053D" Value="Immortal Shard"/>
+        <handlers:Item Key="item053E" Value="Nergigante Cortex"/>
+        <handlers:Item Key="item053F" Value="Nergigante Flail"/>
+        <handlers:Item Key="item0540" Value="Annihilating Greathorn"/>
+        <handlers:Item Key="item0541" Value="Nergigante Hardclaw"/>
+        <handlers:Item Key="item0542" Value="Eternal Regrowth Plate"/>
+        <handlers:Item Key="item0543" Value="Crystal Shard"/>
+        <handlers:Item Key="item0544" Value="Velkhana Cortex"/>
+        <handlers:Item Key="item0545" Value="Velkhana Fellwing"/>
+        <handlers:Item Key="item0546" Value="Velkhana Crownhorn"/>
+        <handlers:Item Key="item0547" Value="Velkhana Lash"/>
+        <handlers:Item Key="item0548" Value="Velkhana Hardclaw"/>
+        <handlers:Item Key="item0549" Value="Velkhana Crystal"/>
+        <handlers:Item Key="item054A" Value="Teostra Cortex"/>
+        <handlers:Item Key="item054B" Value="Teostra Mane+"/>
+        <handlers:Item Key="item054C" Value="Teostra Lash"/>
+        <handlers:Item Key="item054D" Value="Teostra Hardhorn"/>
+        <handlers:Item Key="item054E" Value="Hellfire Shard"/>
+        <handlers:Item Key="item054F" Value="Fire Dragon Hardclaw"/>
+        <handlers:Item Key="item0550" Value="Teostra Fellwing"/>
+        <handlers:Item Key="item0551" Value="Lunastra Cortex"/>
+        <handlers:Item Key="item0552" Value="Lunastra Mane+"/>
+        <handlers:Item Key="item0553" Value="Lunastra Lash"/>
+        <handlers:Item Key="item0554" Value="Lunastra Hardhorn"/>
+        <handlers:Item Key="item0555" Value="Lunastra Shard"/>
+        <handlers:Item Key="item0556" Value="Lunastra Fellwing"/>
+        <handlers:Item Key="item0557" Value="Daora Cortex"/>
+        <handlers:Item Key="item0558" Value="Daora Shard"/>
+        <handlers:Item Key="item0559" Value="Daora Fellwing"/>
+        <handlers:Item Key="item055A" Value="Daora Hardhorn"/>
+        <handlers:Item Key="item055B" Value="Daora Lash"/>
+        <handlers:Item Key="item055C" Value="Daora Hardclaw"/>
+        <handlers:Item Key="item055D" Value="Deceased Shard"/>
+        <handlers:Item Key="item055E" Value="Vaal Hazak Cortex"/>
+        <handlers:Item Key="item055F" Value="Deathweaver Membrane"/>
+        <handlers:Item Key="item0560" Value="Vaal Hazak Flail"/>
+        <handlers:Item Key="item0561" Value="Shadowpierce Fang"/>
+        <handlers:Item Key="item0562" Value="Vaal Hazak Hardclaw"/>
+        <handlers:Item Key="item0563" Value="Vaal Hazak Fellwing"/>
+        <handlers:Item Key="item0564" Value="Namielle Finehide"/>
+        <handlers:Item Key="item0565" Value="Item 1381"/>
+        <handlers:Item Key="item0566" Value="Namielle Fellwing"/>
+        <handlers:Item Key="item0567" Value="Namielle Whisker"/>
+        <handlers:Item Key="item0568" Value="Namielle Lash"/>
+        <handlers:Item Key="item0569" Value="Namielle Hardclaw"/>
+        <handlers:Item Key="item056A" Value="Item 1386"/>
+        <handlers:Item Key="item056B" Value="Item 1387"/>
+        <handlers:Item Key="item056C" Value="Item 1388"/>
+        <handlers:Item Key="item056D" Value="Item 1389"/>
+        <handlers:Item Key="item056E" Value="Item 1390"/>
+        <handlers:Item Key="item056F" Value="Item 1391"/>
+        <handlers:Item Key="item0570" Value="Item 1392"/>
+        <handlers:Item Key="item0571" Value="Item 1393"/>
+        <handlers:Item Key="item0572" Value="Item 1394"/>
+        <handlers:Item Key="item0573" Value="Shara Ishvalda Tenderscale"/>
+        <handlers:Item Key="item0574" Value="Shara Ishvalda Boulderplate"/>
+        <handlers:Item Key="item0575" Value="Item 1397"/>
+        <handlers:Item Key="item0576" Value="Shara Ishvalda Tenderplate"/>
+        <handlers:Item Key="item0577" Value="Shara Ishvalda Petalstone"/>
+        <handlers:Item Key="item0578" Value="Shara Ishvalda Tenderclaw"/>
+        <handlers:Item Key="item0579" Value="Shara Ishvalda Gem"/>
+        <handlers:Item Key="item057A" Value="Item 1402"/>
+        <handlers:Item Key="item057B" Value="Item 1403"/>
+        <handlers:Item Key="item057C" Value="Item 1404"/>
+        <handlers:Item Key="item057D" Value="Item 1405"/>
+        <handlers:Item Key="item057E" Value="Item 1406"/>
+        <handlers:Item Key="item057F" Value="Item 1407"/>
+        <handlers:Item Key="item0580" Value="Item 1408"/>
+        <handlers:Item Key="item0581" Value="Ancient Feystone"/>
+        <handlers:Item Key="item0582" Value="Carved Feystone"/>
+        <handlers:Item Key="item0583" Value="Sealed Feystone"/>
+        <handlers:Item Key="item0584" Value="Decayed Scale"/>
+        <handlers:Item Key="item0585" Value="Luminous Scale"/>
+        <handlers:Item Key="item0586" Value="Old Dragon Treasure"/>
+        <handlers:Item Key="item0587" Value="Item 1415"/>
+        <handlers:Item Key="item0588" Value="Item 1416"/>
+        <handlers:Item Key="item0589" Value="??? Shard"/>
+        <handlers:Item Key="item058A" Value="??? Boulderplate"/>
+        <handlers:Item Key="item058B" Value="??? Cortex"/>
+        <handlers:Item Key="item058C" Value="??? Rock"/>
+        <handlers:Item Key="item058D" Value="??? Hardclaw"/>
+        <handlers:Item Key="item058E" Value="Large ??? Gem"/>
+        <handlers:Item Key="item058F" Value="Item 1423"/>
+        <handlers:Item Key="item0590" Value="Item 1424"/>
+        <handlers:Item Key="item0591" Value="Item 1425"/>
+        <handlers:Item Key="item0592" Value="Item 1426"/>
+        <handlers:Item Key="item0593" Value="Item 1427"/>
+        <handlers:Item Key="item0594" Value="Item 1428"/>
+        <handlers:Item Key="item0595" Value="Item 1429"/>
+        <handlers:Item Key="item0596" Value="Item 1430"/>
+        <handlers:Item Key="item0597" Value="天の竜人手形"/>
+        <handlers:Item Key="item0598" Value="Conqueror's Seal"/>
+        <handlers:Item Key="item0599" Value="Research Commission Ticket+"/>
+        <handlers:Item Key="item059A" Value="Banbaro Coin"/>
+        <handlers:Item Key="item059B" Value="Paolumu Coin"/>
+        <handlers:Item Key="item059C" Value="Nargacuga Coin"/>
+        <handlers:Item Key="item059D" Value="Glavenus Coin"/>
+        <handlers:Item Key="item059E" Value="Odogaron Coin"/>
+        <handlers:Item Key="item059F" Value="Zinogre Coin"/>
+        <handlers:Item Key="item05A0" Value="Black Belt Coin"/>
+        <handlers:Item Key="item05A1" Value="英雄王のコイン"/>
+        <handlers:Item Key="item05A2" Value="Tigrex Coin"/>
+        <handlers:Item Key="item05A3" Value="Giant Scale"/>
+        <handlers:Item Key="item05A4" Value="Magnificent Scale"/>
+        <handlers:Item Key="item05A5" Value="Boaboa Ticket"/>
+        <handlers:Item Key="item05A6" Value="Young Butterbur"/>
+        <handlers:Item Key="item05A7" Value="Exquisite Butterbur"/>
+        <handlers:Item Key="item05A8" Value="Millennium Butterbur"/>
+        <handlers:Item Key="item05A9" Value="Icebloom"/>
+        <handlers:Item Key="item05AA" Value="Moonlight Icebloom"/>
+        <handlers:Item Key="item05AB" Value="Snowpeak Icebloom"/>
+        <handlers:Item Key="item05AC" Value="スノーホワイト"/>
+        <handlers:Item Key="item05AD" Value="Petalcryst"/>
+        <handlers:Item Key="item05AE" Value="EZ Dust of Life"/>
+        <handlers:Item Key="item05AF" Value="Pearlspring Macaque"/>
+        <handlers:Item Key="item05B0" Value="Goldspring Macaque"/>
+        <handlers:Item Key="item05B1" Value="Item 1457"/>
+        <handlers:Item Key="item05B2" Value="Crowned Prawn"/>
+        <handlers:Item Key="item05B3" Value="Moon Slug"/>
+        <handlers:Item Key="item05B4" Value="Duffel Penguin"/>
+        <handlers:Item Key="item05B5" Value="Arrowhead Gekko"/>
+        <handlers:Item Key="item05B6" Value="Blue Diva"/>
+        <handlers:Item Key="item05B7" Value="ワダツミノツカイ"/>
+        <handlers:Item Key="item05B8" Value="グラスパレクス"/>
+        <handlers:Item Key="item05B9" Value="ツキノハゴロモ"/>
+        <handlers:Item Key="item05BA" Value="Moly"/>
+        <handlers:Item Key="item05BB" Value="Mossy Moly"/>
+        <handlers:Item Key="item05BC" Value="Rocky Moly"/>
+        <handlers:Item Key="item05BD" Value="Fluffy Moly"/>
+        <handlers:Item Key="item05BE" Value="Spiny Moly"/>
+        <handlers:Item Key="item05BF" Value="Item 1471"/>
+        <handlers:Item Key="item05C0" Value="Item 1472"/>
+        <handlers:Item Key="item05C1" Value="ドスグラスパレクス"/>
+        <handlers:Item Key="item05C2" Value="Item 1474"/>
+        <handlers:Item Key="item05C3" Value="Item 1475"/>
+        <handlers:Item Key="item05C4" Value="Item 1476"/>
+        <handlers:Item Key="item05C5" Value="Item 1477"/>
+        <handlers:Item Key="item05C6" Value="Dragonvein Shard"/>
+        <handlers:Item Key="item05C7" Value="Dragonvein Coal"/>
+        <handlers:Item Key="item05C8" Value="Dragonvein Coal Chunk"/>
+        <handlers:Item Key="item05C9" Value="Cloth Curtain (Small)"/>
+        <handlers:Item Key="item05CA" Value="Pelt Curtain (Small)"/>
+        <handlers:Item Key="item05CB" Value="Elegant Curtain (Small)"/>
+        <handlers:Item Key="item05CC" Value="Item 1484"/>
+        <handlers:Item Key="item05CD" Value="Cloth Curtain (Large)"/>
+        <handlers:Item Key="item05CE" Value="Pelt Curtain (Large)"/>
+        <handlers:Item Key="item05CF" Value="Elegant Curtain (Large)"/>
+        <handlers:Item Key="item05D0" Value="Item 1488"/>
+        <handlers:Item Key="item05D1" Value="Familiar Sofa"/>
+        <handlers:Item Key="item05D2" Value="Item 1490"/>
+        <handlers:Item Key="item05D3" Value="Luxury Sofa"/>
+        <handlers:Item Key="item05D4" Value="Elegant Sofa"/>
+        <handlers:Item Key="item05D5" Value="Item 1493"/>
+        <handlers:Item Key="item05D6" Value="Rustic Bed"/>
+        <handlers:Item Key="item05D7" Value="Familiar Bed"/>
+        <handlers:Item Key="item05D8" Value="Luxury Bed"/>
+        <handlers:Item Key="item05D9" Value="Item 1497"/>
+        <handlers:Item Key="item05DA" Value="Familiar Table"/>
+        <handlers:Item Key="item05DB" Value="Luxury Table"/>
+        <handlers:Item Key="item05DC" Value="Elegant Table"/>
+        <handlers:Item Key="item05DD" Value="Item 1501"/>
+        <handlers:Item Key="item05DE" Value="Rustic Chairs"/>
+        <handlers:Item Key="item05DF" Value="Familiar Chairs"/>
+        <handlers:Item Key="item05E0" Value="Luxury Chairs"/>
+        <handlers:Item Key="item05E1" Value="Elegant Chairs"/>
+        <handlers:Item Key="item05E2" Value="Item 1506"/>
+        <handlers:Item Key="item05E3" Value="Carnivore Carnival"/>
+        <handlers:Item Key="item05E4" Value="Party Platter"/>
+        <handlers:Item Key="item05E5" Value="Tropical Lunch"/>
+        <handlers:Item Key="item05E6" Value="Sumptuous Stew"/>
+        <handlers:Item Key="item05E7" Value="Hunter's Brunch"/>
+        <handlers:Item Key="item05E8" Value="Familiar Chest"/>
+        <handlers:Item Key="item05E9" Value="Luxury Chest"/>
+        <handlers:Item Key="item05EA" Value="Item 1514"/>
+        <handlers:Item Key="item05EB" Value="Hoarfrost Reach Plant 1"/>
+        <handlers:Item Key="item05EC" Value="Hoarfrost Reach Plant 2"/>
+        <handlers:Item Key="item05ED" Value="Item 1517"/>
+        <handlers:Item Key="item05EE" Value="Hoarfrost Reach Plant 3"/>
+        <handlers:Item Key="item05EF" Value="Ancient Forest Plant 1"/>
+        <handlers:Item Key="item05F0" Value="Item 1520"/>
+        <handlers:Item Key="item05F1" Value="Ancient Forest Plant 4"/>
+        <handlers:Item Key="item05F2" Value="Ancient Forest Plant 5"/>
+        <handlers:Item Key="item05F3" Value="Ancient Forest Plant 3"/>
+        <handlers:Item Key="item05F4" Value="Wildspire Wastes Plant 2"/>
+        <handlers:Item Key="item05F5" Value="Item 1525"/>
+        <handlers:Item Key="item05F6" Value="Wildspire Wastes Plant 1"/>
+        <handlers:Item Key="item05F7" Value="Ancient Forest Plant 2"/>
+        <handlers:Item Key="item05F8" Value="Item 1528"/>
+        <handlers:Item Key="item05F9" Value="Item 1529"/>
+        <handlers:Item Key="item05FA" Value="Simple Urn"/>
+        <handlers:Item Key="item05FB" Value="Grimalkyne Doll"/>
+        <handlers:Item Key="item05FC" Value="Gajalaka Doll"/>
+        <handlers:Item Key="item05FD" Value="Boaboa Doll"/>
+        <handlers:Item Key="item05FE" Value="Felyne Doll"/>
+        <handlers:Item Key="item05FF" Value="Grimalkyne Doll (Black)"/>
+        <handlers:Item Key="item0600" Value="Grimalkyne Doll (Navy)"/>
+        <handlers:Item Key="item0601" Value="Grimalkyne Doll (Blue)"/>
+        <handlers:Item Key="item0602" Value="Poogie Doll (Memorial Stripes)"/>
+        <handlers:Item Key="item0603" Value="Poogie Doll (Emperor's Duds)"/>
+        <handlers:Item Key="item0604" Value="Item 1540"/>
+        <handlers:Item Key="item0605" Value="Item 1541"/>
+        <handlers:Item Key="item0606" Value="Item 1542"/>
+        <handlers:Item Key="item0607" Value="Item 1543"/>
+        <handlers:Item Key="item0608" Value="Item 1544"/>
+        <handlers:Item Key="item0609" Value="Simple Urn Set"/>
+        <handlers:Item Key="item060A" Value="Burlap Sacks"/>
+        <handlers:Item Key="item060B" Value="Bottled Spirit"/>
+        <handlers:Item Key="item060C" Value="Assorted Bottle Set"/>
+        <handlers:Item Key="item060D" Value="Crafting Tools"/>
+        <handlers:Item Key="item060E" Value="Dyed Silk Rolls"/>
+        <handlers:Item Key="item060F" Value="Ornamental Horn"/>
+        <handlers:Item Key="item0610" Value="Display Fossil"/>
+        <handlers:Item Key="item0611" Value="Simple Pottery"/>
+        <handlers:Item Key="item0612" Value="Pottery Set"/>
+        <handlers:Item Key="item0613" Value="Item 1555"/>
+        <handlers:Item Key="item0614" Value="Ornamental Plate (Large)"/>
+        <handlers:Item Key="item0615" Value="Basket of Ore"/>
+        <handlers:Item Key="item0616" Value="Item 1558"/>
+        <handlers:Item Key="item0617" Value="First Aid Kit"/>
+        <handlers:Item Key="item0618" Value="Item 1560"/>
+        <handlers:Item Key="item0619" Value="Potted Plant"/>
+        <handlers:Item Key="item061A" Value="Research Tomes"/>
+        <handlers:Item Key="item061B" Value="Scholarly Tomes"/>
+        <handlers:Item Key="item061C" Value="Refined Vase (Large)"/>
+        <handlers:Item Key="item061D" Value="Potted Cactus"/>
+        <handlers:Item Key="item061E" Value="Colorful Planting"/>
+        <handlers:Item Key="item061F" Value="Basket of Mushrooms"/>
+        <handlers:Item Key="item0620" Value="Item 1568"/>
+        <handlers:Item Key="item0621" Value="Vegetable Display"/>
+        <handlers:Item Key="item0622" Value="Fierce Gajalaka Mask"/>
+        <handlers:Item Key="item0623" Value="Grimacing Gajalaka Mask"/>
+        <handlers:Item Key="item0624" Value="Surprised Gajalaka Mask"/>
+        <handlers:Item Key="item0625" Value="Amber"/>
+        <handlers:Item Key="item0626" Value="Item 1574"/>
+        <handlers:Item Key="item0627" Value="Item 1575"/>
+        <handlers:Item Key="item0628" Value="Seashell"/>
+        <handlers:Item Key="item0629" Value="Symbol of Assistance"/>
+        <handlers:Item Key="item062A" Value="Symbol of Contribution"/>
+        <handlers:Item Key="item062B" Value="Symbol of Dedication"/>
+        <handlers:Item Key="item062C" Value="Symbol of Valor"/>
+        <handlers:Item Key="item062D" Value="Goldenfry Mobile"/>
+        <handlers:Item Key="item062E" Value="Whetfish Mobile"/>
+        <handlers:Item Key="item062F" Value="Marlin Mobile"/>
+        <handlers:Item Key="item0630" Value="Item 1584"/>
+        <handlers:Item Key="item0631" Value="Item 1585"/>
+        <handlers:Item Key="item0632" Value="Item 1586"/>
+        <handlers:Item Key="item0633" Value="Barrel Ornament"/>
+        <handlers:Item Key="item0634" Value="Catch-of-the-Day Ornament"/>
+        <handlers:Item Key="item0635" Value="Fish Ornament"/>
+        <handlers:Item Key="item0636" Value="Marlin Ornament"/>
+        <handlers:Item Key="item0637" Value="Elegant Flag"/>
+        <handlers:Item Key="item0638" Value="Nargacuga Painting"/>
+        <handlers:Item Key="item0639" Value="Research Base Painting"/>
+        <handlers:Item Key="item063A" Value="Handler Portrait"/>
+        <handlers:Item Key="item063B" Value="Elegant Ornamental Plate"/>
+        <handlers:Item Key="item063C" Value="Gajalaka Painting 1"/>
+        <handlers:Item Key="item063D" Value="Boaboa Painting 1"/>
+        <handlers:Item Key="item063E" Value="Grimalkyne Painting 1"/>
+        <handlers:Item Key="item063F" Value="Poogie Painting"/>
+        <handlers:Item Key="item0640" Value="Palico Portraits"/>
+        <handlers:Item Key="item0641" Value="Item 1601"/>
+        <handlers:Item Key="item0642" Value="Item 1602"/>
+        <handlers:Item Key="item0643" Value="Item 1603"/>
+        <handlers:Item Key="item0644" Value="Item 1604"/>
+        <handlers:Item Key="item0645" Value="Familiar Desk"/>
+        <handlers:Item Key="item0646" Value="Luxury Desk"/>
+        <handlers:Item Key="item0647" Value="Item 1607"/>
+        <handlers:Item Key="item0648" Value="Familiar Shelves"/>
+        <handlers:Item Key="item0649" Value="Intellectual Shelves"/>
+        <handlers:Item Key="item064A" Value="Cluttered Shelves"/>
+        <handlers:Item Key="item064B" Value="Luxury Shelves"/>
+        <handlers:Item Key="item064C" Value="Elegant Shelves"/>
+        <handlers:Item Key="item064D" Value="Item 1613"/>
+        <handlers:Item Key="item064E" Value="Item 1614"/>
+        <handlers:Item Key="item064F" Value="Familiar Lights"/>
+        <handlers:Item Key="item0650" Value="Sturdy Lights"/>
+        <handlers:Item Key="item0651" Value="Luxury Lights"/>
+        <handlers:Item Key="item0652" Value="Item 1618"/>
+        <handlers:Item Key="item0653" Value="Simple Lights"/>
+        <handlers:Item Key="item0654" Value="Item 1620"/>
+        <handlers:Item Key="item0655" Value="Item 1621"/>
+        <handlers:Item Key="item0656" Value="Item 1622"/>
+        <handlers:Item Key="item0657" Value="Familiar Rack"/>
+        <handlers:Item Key="item0658" Value="Luxury Rack"/>
+        <handlers:Item Key="item0659" Value="Item 1625"/>
+        <handlers:Item Key="item065A" Value="Simple Wall Shelf (Large)"/>
+        <handlers:Item Key="item065B" Value="Luxury Wall Shelf (Large)"/>
+        <handlers:Item Key="item065C" Value="Item 1628"/>
+        <handlers:Item Key="item065D" Value="Simple Wall Shelf (Small)"/>
+        <handlers:Item Key="item065E" Value="Luxury Wall Shelf (Small)"/>
+        <handlers:Item Key="item065F" Value="Item 1631"/>
+        <handlers:Item Key="item0660" Value="Item 1632"/>
+        <handlers:Item Key="item0661" Value="Item 1633"/>
+        <handlers:Item Key="item0662" Value="Zorah Magdaros Painting"/>
+        <handlers:Item Key="item0663" Value="Cloth Wall-Hanging"/>
+        <handlers:Item Key="item0664" Value="Fur Wall-Hanging"/>
+        <handlers:Item Key="item0665" Value="Ship's Wheel Wall-Hanging"/>
+        <handlers:Item Key="item0666" Value="Item 1638"/>
+        <handlers:Item Key="item0667" Value="Gajalaka Painting 2"/>
+        <handlers:Item Key="item0668" Value="Boaboa Painting 2"/>
+        <handlers:Item Key="item0669" Value="Grimalkyne Painting 2"/>
+        <handlers:Item Key="item066A" Value="Ancient Forest Painting"/>
+        <handlers:Item Key="item066B" Value="Wildspire Wastes Painting"/>
+        <handlers:Item Key="item066C" Value="Coral Highlands Painting"/>
+        <handlers:Item Key="item066D" Value="Rotten Vale Painting"/>
+        <handlers:Item Key="item066E" Value="Elder's Recess Painting"/>
+        <handlers:Item Key="item066F" Value="Hoarfrost Reach Painting"/>
+        <handlers:Item Key="item0670" Value="Books and Documents"/>
+        <handlers:Item Key="item0671" Value="Healthy Refreshments"/>
+        <handlers:Item Key="item0672" Value="Item 1650"/>
+        <handlers:Item Key="item0673" Value="Maps"/>
+        <handlers:Item Key="item0674" Value="Crafting Set"/>
+        <handlers:Item Key="item0675" Value="Baking Set"/>
+        <handlers:Item Key="item0676" Value="Tool Set"/>
+        <handlers:Item Key="item0677" Value="Familiar Rugs (1F)"/>
+        <handlers:Item Key="item0678" Value="Luxury Rugs (1F)"/>
+        <handlers:Item Key="item0679" Value="Item 1657"/>
+        <handlers:Item Key="item067A" Value="Fur Rugs (1F)"/>
+        <handlers:Item Key="item067B" Value="Familiar Rugs (2F)"/>
+        <handlers:Item Key="item067C" Value="Luxury Rugs (2F)"/>
+        <handlers:Item Key="item067D" Value="Item 1661"/>
+        <handlers:Item Key="item067E" Value="Fur Rugs (2F)"/>
+        <handlers:Item Key="item067F" Value="Lantern"/>
+        <handlers:Item Key="item0680" Value="Item 1664"/>
+        <handlers:Item Key="item0681" Value="Item 1665"/>
+        <handlers:Item Key="item0682" Value="Candle"/>
+        <handlers:Item Key="item0683" Value="Candlestick"/>
+        <handlers:Item Key="item0684" Value="Songbird Lamp"/>
+        <handlers:Item Key="item0685" Value="Jellyfish Lamp"/>
+        <handlers:Item Key="item0686" Value="Angler Fish Lamp"/>
+        <handlers:Item Key="item0687" Value="Item 1671"/>
+        <handlers:Item Key="item0688" Value="Item 1672"/>
+        <handlers:Item Key="item0689" Value="Item 1673"/>
+        <handlers:Item Key="item068A" Value="Botanical Pattern"/>
+        <handlers:Item Key="item068B" Value="Elegant Pattern"/>
+        <handlers:Item Key="item068C" Value="Patchwork"/>
+        <handlers:Item Key="item068D" Value="Patchwork (Brown)"/>
+        <handlers:Item Key="item068E" Value="Patchwork (Gray)"/>
+        <handlers:Item Key="item068F" Value="Check (Red)"/>
+        <handlers:Item Key="item0690" Value="Check (White)"/>
+        <handlers:Item Key="item0691" Value="Check (Blue)"/>
+        <handlers:Item Key="item0692" Value="Trap and Beast (Brown)"/>
+        <handlers:Item Key="item0693" Value="Trap and Beast (Navy)"/>
+        <handlers:Item Key="item0694" Value="Trap and Beast (Aqua)"/>
+        <handlers:Item Key="item0695" Value="Trap and Beast (Yellow)"/>
+        <handlers:Item Key="item0696" Value="Wild Nature (Vibrant)"/>
+        <handlers:Item Key="item0697" Value="Wild Nature (Red)"/>
+        <handlers:Item Key="item0698" Value="Wild Nature (Green)"/>
+        <handlers:Item Key="item0699" Value="Nature Check (Green)"/>
+        <handlers:Item Key="item069A" Value="Nature Check (Blue)"/>
+        <handlers:Item Key="item069B" Value="Traditional Pattern (Black)"/>
+        <handlers:Item Key="item069C" Value="Traditional Pattern (Vibrant)"/>
+        <handlers:Item Key="item069D" Value="Traditional Pattern (Brown)"/>
+        <handlers:Item Key="item069E" Value="Traditional Pattern (Pink)"/>
+        <handlers:Item Key="item069F" Value="Traditional Pattern (Aqua)"/>
+        <handlers:Item Key="item06A0" Value="Traditional Pattern (Warm)"/>
+        <handlers:Item Key="item06A1" Value="Traditional Pattern (Red)"/>
+        <handlers:Item Key="item06A2" Value="Hunter Pattern (Brown)"/>
+        <handlers:Item Key="item06A3" Value="Hunter Pattern (White)"/>
+        <handlers:Item Key="item06A4" Value="Hunter Pattern (Gold)"/>
+        <handlers:Item Key="item06A5" Value="Hunter Pattern (Red)"/>
+        <handlers:Item Key="item06A6" Value="Item 1702"/>
+        <handlers:Item Key="item06A7" Value="Item 1703"/>
+        <handlers:Item Key="item06A8" Value="Item 1704"/>
+        <handlers:Item Key="item06A9" Value="Item 1705"/>
+        <handlers:Item Key="item06AA" Value="Item 1706"/>
+        <handlers:Item Key="item06AB" Value="Palico Print (Pink)"/>
+        <handlers:Item Key="item06AC" Value="Palico Print (Brown)"/>
+        <handlers:Item Key="item06AD" Value="Item 1709"/>
+        <handlers:Item Key="item06AE" Value="Item 1710"/>
+        <handlers:Item Key="item06AF" Value="Item 1711"/>
+        <handlers:Item Key="item06B0" Value="Item 1712"/>
+        <handlers:Item Key="item06B1" Value="Item 1713"/>
+        <handlers:Item Key="item06B2" Value="Item 1714"/>
+        <handlers:Item Key="item06B3" Value="Item 1715"/>
+        <handlers:Item Key="item06B4" Value="Item 1716"/>
+        <handlers:Item Key="item06B5" Value="Item 1717"/>
+        <handlers:Item Key="item06B6" Value="Item 1718"/>
+        <handlers:Item Key="item06B7" Value="Item 1719"/>
+        <handlers:Item Key="item06B8" Value="Item 1720"/>
+        <handlers:Item Key="item06B9" Value="Light Wood"/>
+        <handlers:Item Key="item06BA" Value="Dark Wood"/>
+        <handlers:Item Key="item06BB" Value="Light Iron"/>
+        <handlers:Item Key="item06BC" Value="Dark Iron"/>
+        <handlers:Item Key="item06BD" Value="Silver"/>
+        <handlers:Item Key="item06BE" Value="Item 1726"/>
+        <handlers:Item Key="item06BF" Value="Stone"/>
+        <handlers:Item Key="item06C0" Value="Home Sweet Home"/>
+        <handlers:Item Key="item06C1" Value="Traditional Room"/>
+        <handlers:Item Key="item06C2" Value="Item 1730"/>
+        <handlers:Item Key="item06C3" Value="Item 1731"/>
+        <handlers:Item Key="item06C4" Value="Item 1732"/>
+        <handlers:Item Key="item06C5" Value="Item 1733"/>
+        <handlers:Item Key="item06C6" Value="Wooden Floor"/>
+        <handlers:Item Key="item06C7" Value="Chic Wooden Floor"/>
+        <handlers:Item Key="item06C8" Value="Simple Stone Floor"/>
+        <handlers:Item Key="item06C9" Value="Item 1737"/>
+        <handlers:Item Key="item06CA" Value="Item 1738"/>
+        <handlers:Item Key="item06CB" Value="Marble Tile Floor"/>
+        <handlers:Item Key="item06CC" Value="Item 1740"/>
+        <handlers:Item Key="item06CD" Value="Item 1741"/>
+        <handlers:Item Key="item06CE" Value="Item 1742"/>
+        <handlers:Item Key="item06CF" Value="Chic Stone Floor"/>
+        <handlers:Item Key="item06D0" Value="Wooden Wall"/>
+        <handlers:Item Key="item06D1" Value="Chic Wooden Wall"/>
+        <handlers:Item Key="item06D2" Value="Simple Stone Wall"/>
+        <handlers:Item Key="item06D3" Value="Item 1747"/>
+        <handlers:Item Key="item06D4" Value="Item 1748"/>
+        <handlers:Item Key="item06D5" Value="Simple Stucco Wall"/>
+        <handlers:Item Key="item06D6" Value="Item 1750"/>
+        <handlers:Item Key="item06D7" Value="Item 1751"/>
+        <handlers:Item Key="item06D8" Value="Item 1752"/>
+        <handlers:Item Key="item06D9" Value="Item 1753"/>
+        <handlers:Item Key="item06DA" Value="Elegant Stucco Wall"/>
+        <handlers:Item Key="item06DB" Value="Wooden Floor (White)"/>
+        <handlers:Item Key="item06DC" Value="Wooden Floor (Green)"/>
+        <handlers:Item Key="item06DD" Value="Wooden Floor (Blue)"/>
+        <handlers:Item Key="item06DE" Value="Wooden Floor (Red)"/>
+        <handlers:Item Key="item06DF" Value="Wooden Floor (Yellow)"/>
+        <handlers:Item Key="item06E0" Value="Light Wooden Floor"/>
+        <handlers:Item Key="item06E1" Value="Wooden Wall (White)"/>
+        <handlers:Item Key="item06E2" Value="Wooden Wall (Green)"/>
+        <handlers:Item Key="item06E3" Value="Wooden Wall (Blue)"/>
+        <handlers:Item Key="item06E4" Value="Wooden Wall (Red)"/>
+        <handlers:Item Key="item06E5" Value="Wooden Wall (Yellow)"/>
+        <handlers:Item Key="item06E6" Value="Stucco Wall (Orange)"/>
+        <handlers:Item Key="item06E7" Value="Stucco Wall (Green)"/>
+        <handlers:Item Key="item06E8" Value="Stucco Wall (Red)"/>
+        <handlers:Item Key="item06E9" Value="Stucco Wall (Blue)"/>
+        <handlers:Item Key="item06EA" Value="Traditional Bench"/>
+        <handlers:Item Key="item06EB" Value="Traditional Bed"/>
+        <handlers:Item Key="item06EC" Value="Traditional Table"/>
+        <handlers:Item Key="item06ED" Value="Traditional Meal"/>
+        <handlers:Item Key="item06EE" Value="Traditional Chest"/>
+        <handlers:Item Key="item06EF" Value="Traditional Rugs (1F)"/>
+        <handlers:Item Key="item06F0" Value="Traditional Rugs (2F)"/>
+        <handlers:Item Key="item06F1" Value="Traditional Wall"/>
+        <handlers:Item Key="item06F2" Value="Traditional Floor"/>
+        <handlers:Item Key="item06F3" Value="Traditional Lights"/>
+        <handlers:Item Key="item06F4" Value="Item 1780"/>
+        <handlers:Item Key="item06F5" Value="Dragonrazer Fuel Cell"/>
+        <handlers:Item Key="item06F6" Value="Tailraider Signal"/>
+        <handlers:Item Key="item06F7" Value="Item 1783"/>
+        <handlers:Item Key="item06F8" Value="Bugtrappers: Fried Dragonfly"/>
+        <handlers:Item Key="item06F9" Value="Protectors: Dried Goldenfish"/>
+        <handlers:Item Key="item06FA" Value="Troupers: Horned Urchin"/>
+        <handlers:Item Key="item06FB" Value="Plunderers: Steamed Cricket"/>
+        <handlers:Item Key="item06FC" Value="Grimalkyne: Pot-au-magma"/>
+        <handlers:Item Key="item06FD" Value="Boaboa: Boaboa Bread"/>
+        <handlers:Item Key="item06FE" Value="Thermae Ticket"/>
+        <handlers:Item Key="item06FF" Value="Scratched Shell"/>
+        <handlers:Item Key="item0700" Value="Stonebill"/>
+        <handlers:Item Key="item0701" Value="Rime Beetle"/>
+        <handlers:Item Key="item0702" Value="Hot Spring Stone"/>
+        <handlers:Item Key="item0703" Value="Decayed Crystal"/>
+        <handlers:Item Key="item0704" Value="Forest Crystal"/>
+        <handlers:Item Key="item0705" Value="Prosperous Crystal"/>
+        <handlers:Item Key="item0706" Value="Guiding Forest Crystal"/>
+        <handlers:Item Key="item0707" Value="Cracked Crystal"/>
+        <handlers:Item Key="item0708" Value="Wasteland Crystal"/>
+        <handlers:Item Key="item0709" Value="Serene Crystal"/>
+        <handlers:Item Key="item070A" Value="Guiding Wasteland Crystal"/>
+        <handlers:Item Key="item070B" Value="Pale Crystal"/>
+        <handlers:Item Key="item070C" Value="Coral Crystal"/>
+        <handlers:Item Key="item070D" Value="Deepsea Crystal"/>
+        <handlers:Item Key="item070E" Value="Guiding Coral Crystal"/>
+        <handlers:Item Key="item070F" Value="Distorted Crystal"/>
+        <handlers:Item Key="item0710" Value="Effluvial Crystal"/>
+        <handlers:Item Key="item0711" Value="Twilight Crystal"/>
+        <handlers:Item Key="item0712" Value="Guiding Effluvial Crystal"/>
+        <handlers:Item Key="item0713" Value="Item 1811"/>
+        <handlers:Item Key="item0714" Value="Item 1812"/>
+        <handlers:Item Key="item0715" Value="Item 1813"/>
+        <handlers:Item Key="item0716" Value="Item 1814"/>
+        <handlers:Item Key="item0717" Value="Item 1815"/>
+        <handlers:Item Key="item0718" Value="Item 1816"/>
+        <handlers:Item Key="item0719" Value="Item 1817"/>
+        <handlers:Item Key="item071A" Value="Item 1818"/>
+        <handlers:Item Key="item071B" Value="Mossy Greatbone"/>
+        <handlers:Item Key="item071C" Value="Woodland Greatbone"/>
+        <handlers:Item Key="item071D" Value="Slumbering Greatbone"/>
+        <handlers:Item Key="item071E" Value="Guiding Forest Dragonbone"/>
+        <handlers:Item Key="item071F" Value="Weathered Cragbone"/>
+        <handlers:Item Key="item0720" Value="Wasteland Cragbone"/>
+        <handlers:Item Key="item0721" Value="Tempered Cragbone"/>
+        <handlers:Item Key="item0722" Value="Guiding Wasteland Dragonbone"/>
+        <handlers:Item Key="item0723" Value="Vivid Crimsonbone"/>
+        <handlers:Item Key="item0724" Value="Coral Crimsonbone"/>
+        <handlers:Item Key="item0725" Value="Vibrant Crimsonbone"/>
+        <handlers:Item Key="item0726" Value="Guiding Coral Dragonbone"/>
+        <handlers:Item Key="item0727" Value="Malformed Frenzybone"/>
+        <handlers:Item Key="item0728" Value="Effluvial Frenzybone"/>
+        <handlers:Item Key="item0729" Value="Afflicted Frenzybone"/>
+        <handlers:Item Key="item072A" Value="Guiding Rotted Dragonbone"/>
+        <handlers:Item Key="item072B" Value="Item 1835"/>
+        <handlers:Item Key="item072C" Value="Item 1836"/>
+        <handlers:Item Key="item072D" Value="Item 1837"/>
+        <handlers:Item Key="item072E" Value="Item 1838"/>
+        <handlers:Item Key="item072F" Value="Item 1839"/>
+        <handlers:Item Key="item0730" Value="Item 1840"/>
+        <handlers:Item Key="item0731" Value="Item 1841"/>
+        <handlers:Item Key="item0732" Value="Item 1842"/>
+        <handlers:Item Key="item0733" Value="Fierce Dragonvein Bone"/>
+        <handlers:Item Key="item0734" Value="Heavy Dragonvein Bone"/>
+        <handlers:Item Key="item0735" Value="Dragonvein Solidbone"/>
+        <handlers:Item Key="item0736" Value="Elder Dragonvein Bone"/>
+        <handlers:Item Key="item0737" Value="Item 1847"/>
+        <handlers:Item Key="item0738" Value="Spiritvein Slogbone"/>
+        <handlers:Item Key="item0739" Value="Spiritvein Solidbone"/>
+        <handlers:Item Key="item073A" Value="Elder Spiritvein Bone"/>
+        <handlers:Item Key="item073B" Value="Spiritvein Gem Shard"/>
+        <handlers:Item Key="item073C" Value="Spiritvein Gem"/>
+        <handlers:Item Key="item073D" Value="Great Spiritvein Gem"/>
+        <handlers:Item Key="item073E" Value="Rugged Mane"/>
+        <handlers:Item Key="item073F" Value="Item 1855"/>
+        <handlers:Item Key="item0740" Value="Colorful Plume"/>
+        <handlers:Item Key="item0741" Value="Item 1857"/>
+        <handlers:Item Key="item0742" Value="Fragrant Poison Sac"/>
+        <handlers:Item Key="item0743" Value="Tempered Poison Sac"/>
+        <handlers:Item Key="item0744" Value="Hydrated Sac"/>
+        <handlers:Item Key="item0745" Value="Tempered Torrent Sac"/>
+        <handlers:Item Key="item0746" Value="Muddy Crown"/>
+        <handlers:Item Key="item0747" Value="Tempered Crown"/>
+        <handlers:Item Key="item0748" Value="Item 1864"/>
+        <handlers:Item Key="item0749" Value="Item 1865"/>
+        <handlers:Item Key="item074A" Value="Item 1866"/>
+        <handlers:Item Key="item074B" Value="Item 1867"/>
+        <handlers:Item Key="item074C" Value="Blinding Cathode"/>
+        <handlers:Item Key="item074D" Value="Tempered Cathode"/>
+        <handlers:Item Key="item074E" Value="Item 1870"/>
+        <handlers:Item Key="item074F" Value="Item 1871"/>
+        <handlers:Item Key="item0750" Value="Ancient Great Horn"/>
+        <handlers:Item Key="item0751" Value="Tempered Great Horn"/>
+        <handlers:Item Key="item0752" Value="Flickering Flamepelt"/>
+        <handlers:Item Key="item0753" Value="Tempered Flamepelt"/>
+        <handlers:Item Key="item0754" Value="Crackling Thunderpelt"/>
+        <handlers:Item Key="item0755" Value="Tempered Thunderpelt"/>
+        <handlers:Item Key="item0756" Value="Queen's Scale"/>
+        <handlers:Item Key="item0757" Value="Tempered Green Scale"/>
+        <handlers:Item Key="item0758" Value="Pink Scale"/>
+        <handlers:Item Key="item0759" Value="Tempered Pink Scale"/>
+        <handlers:Item Key="item075A" Value="Dazzling Photophore+"/>
+        <handlers:Item Key="item075B" Value="Item 1883"/>
+        <handlers:Item Key="item075C" Value="Rubbery Shell"/>
+        <handlers:Item Key="item075D" Value="Tempered Rubbery Shell"/>
+        <handlers:Item Key="item075E" Value="Obsidian Fur"/>
+        <handlers:Item Key="item075F" Value="Tempered Hide"/>
+        <handlers:Item Key="item0760" Value="Night Hood"/>
+        <handlers:Item Key="item0761" Value="Item 1889"/>
+        <handlers:Item Key="item0762" Value="Inkstained Oilshell+"/>
+        <handlers:Item Key="item0763" Value="Tempered Oilshell+"/>
+        <handlers:Item Key="item0764" Value="Item 1892"/>
+        <handlers:Item Key="item0765" Value="Item 1893"/>
+        <handlers:Item Key="item0766" Value="Item 1894"/>
+        <handlers:Item Key="item0767" Value="Item 1895"/>
+        <handlers:Item Key="item0768" Value="Item 1896"/>
+        <handlers:Item Key="item0769" Value="Item 1897"/>
+        <handlers:Item Key="item076A" Value="Item 1898"/>
+        <handlers:Item Key="item076B" Value="Item 1899"/>
+        <handlers:Item Key="item076C" Value="Sinister Silverpelt"/>
+        <handlers:Item Key="item076D" Value="Tempered Silverpelt"/>
+        <handlers:Item Key="item076E" Value="Smooth Icehide"/>
+        <handlers:Item Key="item076F" Value="Tempered Icehide"/>
+        <handlers:Item Key="item0770" Value="Item 1904"/>
+        <handlers:Item Key="item0771" Value="Item 1905"/>
+        <handlers:Item Key="item0772" Value="Fatal Rendclaw"/>
+        <handlers:Item Key="item0773" Value="Tempered Rendclaw"/>
+        <handlers:Item Key="item0774" Value="Soulrender Talon"/>
+        <handlers:Item Key="item0775" Value="Tempered Talon"/>
+        <handlers:Item Key="item0776" Value="King's Scale"/>
+        <handlers:Item Key="item0777" Value="Tempered Red Scale"/>
+        <handlers:Item Key="item0778" Value="Azure Scale"/>
+        <handlers:Item Key="item0779" Value="Tempered Azure Scale"/>
+        <handlers:Item Key="item077A" Value="Twisted Bravehorn"/>
+        <handlers:Item Key="item077B" Value="Twisted Temperhorn"/>
+        <handlers:Item Key="item077C" Value="Blackcurl Tyranthorn"/>
+        <handlers:Item Key="item077D" Value="Blackcurl Temperhorn"/>
+        <handlers:Item Key="item077E" Value="Assassin Cutwing"/>
+        <handlers:Item Key="item077F" Value="Tempered Cutwing"/>
+        <handlers:Item Key="item0780" Value="Smoldering Tailedge"/>
+        <handlers:Item Key="item0781" Value="Tempered Tailedge"/>
+        <handlers:Item Key="item0782" Value="Honed Tailblade"/>
+        <handlers:Item Key="item0783" Value="Tempered Tailblade"/>
+        <handlers:Item Key="item0784" Value="Item 1924"/>
+        <handlers:Item Key="item0785" Value="Item 1925"/>
+        <handlers:Item Key="item0786" Value="Strongman's Jaw"/>
+        <handlers:Item Key="item0787" Value="Tempered Jaw"/>
+        <handlers:Item Key="item0788" Value="Shuddering Darkjaw"/>
+        <handlers:Item Key="item0789" Value="Tempered Ebonjaw"/>
+        <handlers:Item Key="item078A" Value="Charged Deathly Shocker"/>
+        <handlers:Item Key="item078B" Value="Tempered Shocker"/>
+        <handlers:Item Key="item078C" Value="Item 1932"/>
+        <handlers:Item Key="item078D" Value="Item 1933"/>
+        <handlers:Item Key="item078E" Value="Bloodstained Ebonhide"/>
+        <handlers:Item Key="item078F" Value="Spattered Hide"/>
+        <handlers:Item Key="item0790" Value="Solemn Azure Horn"/>
+        <handlers:Item Key="item0791" Value="Tempered Azure Horn"/>
+        <handlers:Item Key="item0792" Value="Hellfire Mane"/>
+        <handlers:Item Key="item0793" Value="Tempered Crimson Mane"/>
+        <handlers:Item Key="item0794" Value="Stormcall Steelwing"/>
+        <handlers:Item Key="item0795" Value="Tempered Steelwing"/>
+        <handlers:Item Key="item0796" Value="Azure Mane"/>
+        <handlers:Item Key="item0797" Value="Tempered Azure Mane"/>
+        <handlers:Item Key="item0798" Value="Aurora Crownhorn"/>
+        <handlers:Item Key="item0799" Value="Tempered Crownhorn"/>
+        <handlers:Item Key="item079A" Value="Twilight Fang"/>
+        <handlers:Item Key="item079B" Value="Tempered Twilight Fang"/>
+        <handlers:Item Key="item079C" Value="Enchanting Finehide"/>
+        <handlers:Item Key="item079D" Value="Tempered Trancehide"/>
+        <handlers:Item Key="item079E" Value="Extinction Greathorn"/>
+        <handlers:Item Key="item079F" Value="Item 1951"/>
+        <handlers:Item Key="item07A0" Value="Moonlight Scale"/>
+        <handlers:Item Key="item07A1" Value="Item 1953"/>
+        <handlers:Item Key="item07A2" Value="Scorching Scale"/>
+        <handlers:Item Key="item07A3" Value="Item 1955"/>
+        <handlers:Item Key="item07A4" Value="Item 1956"/>
+        <handlers:Item Key="item07A5" Value="Item 1957"/>
+        <handlers:Item Key="item07A6" Value="Item 1958"/>
+        <handlers:Item Key="item07A7" Value="Item 1959"/>
+        <handlers:Item Key="item07A8" Value="Item 1960"/>
+        <handlers:Item Key="item07A9" Value="Item 1961"/>
+        <handlers:Item Key="item07AA" Value="Item 1962"/>
+        <handlers:Item Key="item07AB" Value="Item 1963"/>
+        <handlers:Item Key="item07AC" Value="Special Scope"/>
+        <handlers:Item Key="item07AD" Value="古代竜人の大手形"/>
+        <handlers:Item Key="item07AE" Value="スチームチケット"/>
+        <handlers:Item Key="item07AF" Value="Giant Dragonvein Coal"/>
+        <handlers:Item Key="item07B0" Value="Phoenix Jewel 3"/>
+        <handlers:Item Key="item07B1" Value="Guardian Jewel 2"/>
+        <handlers:Item Key="item07B2" Value="Cooling Jewel 2"/>
+        <handlers:Item Key="item07B3" Value="Fire Res Jewel+ 4"/>
+        <handlers:Item Key="item07B4" Value="Water Res Jewel+ 4"/>
+        <handlers:Item Key="item07B5" Value="Ice Res Jewel+ 4"/>
+        <handlers:Item Key="item07B6" Value="Thunder Res Jewel+ 4"/>
+        <handlers:Item Key="item07B7" Value="Dragon Res Jewel+ 4"/>
+        <handlers:Item Key="item07B8" Value="Blaze Jewel+ 4"/>
+        <handlers:Item Key="item07B9" Value="Stream Jewel+ 4"/>
+        <handlers:Item Key="item07BA" Value="Frost Jewel+ 4"/>
+        <handlers:Item Key="item07BB" Value="Bolt Jewel+ 4"/>
+        <handlers:Item Key="item07BC" Value="Dragon Jewel+ 4"/>
+        <handlers:Item Key="item07BD" Value="Venom Jewel+ 4"/>
+        <handlers:Item Key="item07BE" Value="Paralyzer Jewel+ 4"/>
+        <handlers:Item Key="item07BF" Value="Sleep Jewel+ 4"/>
+        <handlers:Item Key="item07C0" Value="Blast Jewel+ 4"/>
+        <handlers:Item Key="item07C1" Value="Hard Fire Res Jewel 4"/>
+        <handlers:Item Key="item07C2" Value="Hard Water Res Jewel 4"/>
+        <handlers:Item Key="item07C3" Value="Hard Ice Res Jewel 4"/>
+        <handlers:Item Key="item07C4" Value="Hard Thunder Res Jewel 4"/>
+        <handlers:Item Key="item07C5" Value="Hard Dragon Res Jewel 4"/>
+        <handlers:Item Key="item07C6" Value="Antidote Jewel+ 4"/>
+        <handlers:Item Key="item07C7" Value="Antipara Jewel+ 4"/>
+        <handlers:Item Key="item07C8" Value="Pep Jewel+ 4"/>
+        <handlers:Item Key="item07C9" Value="Steadfast Jewel+ 4"/>
+        <handlers:Item Key="item07CA" Value="Antiblast Jewel+ 4"/>
+        <handlers:Item Key="item07CB" Value="Suture Jewel+ 4"/>
+        <handlers:Item Key="item07CC" Value="Def Lock Jewel+ 4"/>
+        <handlers:Item Key="item07CD" Value="Miasma Jewel+ 4"/>
+        <handlers:Item Key="item07CE" Value="Hungerless Jewel+ 4"/>
+        <handlers:Item Key="item07CF" Value="Recovery Jewel+ 4"/>
+        <handlers:Item Key="item07D0" Value="Tip Toe Jewel+ 4"/>
+        <handlers:Item Key="item07D1" Value="Intimidator Jewel+ 4"/>
+        <handlers:Item Key="item07D2" Value="Meowster Jewel+ 4"/>
+        <handlers:Item Key="item07D3" Value="Hard Tip Toe Jewel 4"/>
+        <handlers:Item Key="item07D4" Value="Hard Intimidator Jewel 4"/>
+        <handlers:Item Key="item07D5" Value="Hard Meowster Jewel 4"/>
+        <handlers:Item Key="item07D6" Value="Trueshot Jewel+ 4"/>
+        <handlers:Item Key="item07D7" Value="Heavy Artillery Jewel+ 4"/>
+        <handlers:Item Key="item07D8" Value="Botany Jewel+ 4"/>
+        <handlers:Item Key="item07D9" Value="Geology Jewel+ 4"/>
+        <handlers:Item Key="item07DA" Value="Survival Jewel+ 4"/>
+        <handlers:Item Key="item07DB" Value="Mirewalker Jewel+ 4"/>
+        <handlers:Item Key="item07DC" Value="Specimen Jewel+ 4"/>
+        <handlers:Item Key="item07DD" Value="Sonorous Jewel+ 4"/>
+        <handlers:Item Key="item07DE" Value="Hard Botany Jewel+ 4"/>
+        <handlers:Item Key="item07DF" Value="Hard Geology Jewel 4"/>
+        <handlers:Item Key="item07E0" Value="Hard Survival Jewel 4"/>
+        <handlers:Item Key="item07E1" Value="Hard Specimen Jewel 4"/>
+        <handlers:Item Key="item07E2" Value="Enduring Jewel+ 4"/>
+        <handlers:Item Key="item07E3" Value="Defense Jewel+ 4"/>
+        <handlers:Item Key="item07E4" Value="Hard Enduring Jewel 4"/>
+        <handlers:Item Key="item07E5" Value="Hard Defense Jewel 4"/>
+        <handlers:Item Key="item07E6" Value="Artillery Jewel+ 4"/>
+        <handlers:Item Key="item07E7" Value="Earplug Jewel+ 4"/>
+        <handlers:Item Key="item07E8" Value="Wind Resist Jewel+ 4"/>
+        <handlers:Item Key="item07E9" Value="Attack Jewel+ 4"/>
+        <handlers:Item Key="item07EA" Value="Expert Jewel+ 4"/>
+        <handlers:Item Key="item07EB" Value="Handicraft Jewel+ 4"/>
+        <handlers:Item Key="item07EC" Value="Throttle Jewel+ 4"/>
+        <handlers:Item Key="item07ED" Value="Challenger Jewel+ 4"/>
+        <handlers:Item Key="item07EE" Value="Potential Jewel+ 4"/>
+        <handlers:Item Key="item07EF" Value="Furor Jewel+ 4"/>
+        <handlers:Item Key="item07F0" Value="Physique Jewel+ 4"/>
+        <handlers:Item Key="item07F1" Value="Evasion Jewel+ 4"/>
+        <handlers:Item Key="item07F2" Value="Ironwall Jewel+ 4"/>
+        <handlers:Item Key="item07F3" Value="Friendship Jewel+ 4"/>
+        <handlers:Item Key="item07F4" Value="Drain/Physique Jewel 4"/>
+        <handlers:Item Key="item07F5" Value="Fortitude/Physique Jewel 4"/>
+        <handlers:Item Key="item07F6" Value="Crisis/Physique Jewel 4"/>
+        <handlers:Item Key="item07F7" Value="Ironwall/Physique Jewel 4"/>
+        <handlers:Item Key="item07F8" Value="Friendship/Physique Jewel 4"/>
+        <handlers:Item Key="item07F9" Value="Satiated/Physique Jewel 4"/>
+        <handlers:Item Key="item07FA" Value="Stonethrower/Physique Jewel 4"/>
+        <handlers:Item Key="item07FB" Value="Resistor/Physique Jewel 4"/>
+        <handlers:Item Key="item07FC" Value="Flight/Physique Jewel 4"/>
+        <handlers:Item Key="item07FD" Value="Sprinter/Physique Jewel 4"/>
+        <handlers:Item Key="item07FE" Value="Refresh/Physique Jewel 4"/>
+        <handlers:Item Key="item07FF" Value="Jumping/Physique Jewel 4"/>
+        <handlers:Item Key="item0800" Value="Sheath/Physique Jewel 4"/>
+        <handlers:Item Key="item0801" Value="Gobbler/Physique Jewel 4"/>
+        <handlers:Item Key="item0802" Value="Grinder/Physique Jewel 4"/>
+        <handlers:Item Key="item0803" Value="Bomber/Physique Jewel 4"/>
+        <handlers:Item Key="item0804" Value="Fungiform/Physique Jewel 4"/>
+        <handlers:Item Key="item0805" Value="Slider/Physique Jewel 4"/>
+        <handlers:Item Key="item0806" Value="Guardian/Physique Jewel 4"/>
+        <handlers:Item Key="item0807" Value="Drain/Evasion Jewel 4"/>
+        <handlers:Item Key="item0808" Value="Fortitude/Evasion Jewel 4"/>
+        <handlers:Item Key="item0809" Value="Crisis/Evasion Jewel 4"/>
+        <handlers:Item Key="item080A" Value="Ironwall/Evasion Jewel 4"/>
+        <handlers:Item Key="item080B" Value="Friendship/Evasion Jewel 4"/>
+        <handlers:Item Key="item080C" Value="Satiated/Evasion Jewel 4"/>
+        <handlers:Item Key="item080D" Value="Stonethrower/Evasion Jewel 4"/>
+        <handlers:Item Key="item080E" Value="Resistor/Evasion Jewel 4"/>
+        <handlers:Item Key="item080F" Value="Flight/Evasion Jewel 4"/>
+        <handlers:Item Key="item0810" Value="Sprinter/Evasion Jewel 4"/>
+        <handlers:Item Key="item0811" Value="Refresh/Evasion Jewel 4"/>
+        <handlers:Item Key="item0812" Value="Jumping/Evasion Jewel 4"/>
+        <handlers:Item Key="item0813" Value="Sheath/Evasion Jewel 4"/>
+        <handlers:Item Key="item0814" Value="Gobbler/Evasion Jewel 4"/>
+        <handlers:Item Key="item0815" Value="Grinder/Evasion Jewel 4"/>
+        <handlers:Item Key="item0816" Value="Bomber/Evasion Jewel 4"/>
+        <handlers:Item Key="item0817" Value="Fungiform/Evasion Jewel 4"/>
+        <handlers:Item Key="item0818" Value="Slider/Evasion Jewel 4"/>
+        <handlers:Item Key="item0819" Value="Guardian/Evasion Jewel 4"/>
+        <handlers:Item Key="item081A" Value="Drain/Attack Jewel 4"/>
+        <handlers:Item Key="item081B" Value="Fortitude/Attack Jewel 4"/>
+        <handlers:Item Key="item081C" Value="Crisis/Attack Jewel 4"/>
+        <handlers:Item Key="item081D" Value="Ironwall/Attack Jewel 4"/>
+        <handlers:Item Key="item081E" Value="Friendship/Attack Jewel 4"/>
+        <handlers:Item Key="item081F" Value="Satiated/Attack Jewel 4"/>
+        <handlers:Item Key="item0820" Value="Stonethrower/Attack Jewel 4"/>
+        <handlers:Item Key="item0821" Value="Resistor/Attack Jewel 4"/>
+        <handlers:Item Key="item0822" Value="Flight/Attack Jewel 4"/>
+        <handlers:Item Key="item0823" Value="Sprinter/Attack Jewel 4"/>
+        <handlers:Item Key="item0824" Value="Refresh/Attack Jewel 4"/>
+        <handlers:Item Key="item0825" Value="Jumping/Attack Jewel 4"/>
+        <handlers:Item Key="item0826" Value="Sheath/Attack Jewel 4"/>
+        <handlers:Item Key="item0827" Value="Gobbler/Attack Jewel 4"/>
+        <handlers:Item Key="item0828" Value="Grinder/Attack Jewel 4"/>
+        <handlers:Item Key="item0829" Value="Bomber/Attack Jewel 4"/>
+        <handlers:Item Key="item082A" Value="Fungiform/Attack Jewel 4"/>
+        <handlers:Item Key="item082B" Value="Slider/Attack Jewel 4"/>
+        <handlers:Item Key="item082C" Value="Guardian/Attack Jewel 4"/>
+        <handlers:Item Key="item082D" Value="Drain/Expert Jewel 4"/>
+        <handlers:Item Key="item082E" Value="Fortitude/Expert Jewel 4"/>
+        <handlers:Item Key="item082F" Value="Crisis/Expert Jewel 4"/>
+        <handlers:Item Key="item0830" Value="Ironwall/Expert Jewel 4"/>
+        <handlers:Item Key="item0831" Value="Friendship/Expert Jewel 4"/>
+        <handlers:Item Key="item0832" Value="Satiated/Expert Jewel 4"/>
+        <handlers:Item Key="item0833" Value="Stonethrower/Expert Jewel 4"/>
+        <handlers:Item Key="item0834" Value="Resistor/Expert Jewel 4"/>
+        <handlers:Item Key="item0835" Value="Flight/Expert Jewel 4"/>
+        <handlers:Item Key="item0836" Value="Sprinter/Expert Jewel 4"/>
+        <handlers:Item Key="item0837" Value="Refresh/Expert Jewel 4"/>
+        <handlers:Item Key="item0838" Value="Jumping/Expert Jewel 4"/>
+        <handlers:Item Key="item0839" Value="Sheath/Expert Jewel 4"/>
+        <handlers:Item Key="item083A" Value="Gobbler/Expert Jewel 4"/>
+        <handlers:Item Key="item083B" Value="Grinder/Expert Jewel 4"/>
+        <handlers:Item Key="item083C" Value="Bomber/Expert Jewel 4"/>
+        <handlers:Item Key="item083D" Value="Fungiform/Expert Jewel 4"/>
+        <handlers:Item Key="item083E" Value="Slider/Expert Jewel 4"/>
+        <handlers:Item Key="item083F" Value="Guardian/Expert Jewel 4"/>
+        <handlers:Item Key="item0840" Value="Drain/Release Jewel 4"/>
+        <handlers:Item Key="item0841" Value="Fortitude/Release Jewel 4"/>
+        <handlers:Item Key="item0842" Value="Crisis/Release Jewel 4"/>
+        <handlers:Item Key="item0843" Value="Ironwall/Release Jewel 4"/>
+        <handlers:Item Key="item0844" Value="Friendship/Release Jewel 4"/>
+        <handlers:Item Key="item0845" Value="Satiated/Release Jewel 4"/>
+        <handlers:Item Key="item0846" Value="Stonethrower/Release Jewel 4"/>
+        <handlers:Item Key="item0847" Value="Resistor/Release Jewel 4"/>
+        <handlers:Item Key="item0848" Value="Flight/Release Jewel 4"/>
+        <handlers:Item Key="item0849" Value="Sprinter/Release Jewel 4"/>
+        <handlers:Item Key="item084A" Value="Refresh/Release Jewel 4"/>
+        <handlers:Item Key="item084B" Value="Jumping/Release Jewel 4"/>
+        <handlers:Item Key="item084C" Value="Sheath/Release Jewel 4"/>
+        <handlers:Item Key="item084D" Value="Gobbler/Release Jewel 4"/>
+        <handlers:Item Key="item084E" Value="Grinder/Release Jewel 4"/>
+        <handlers:Item Key="item084F" Value="Bomber/Release Jewel 4"/>
+        <handlers:Item Key="item0850" Value="Fungiform/Release Jewel 4"/>
+        <handlers:Item Key="item0851" Value="Slider/Release Jewel 4"/>
+        <handlers:Item Key="item0852" Value="Guardian/Release Jewel 4"/>
+        <handlers:Item Key="item0853" Value="Drain/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0854" Value="Fortitude/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0855" Value="Crisis/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0856" Value="Ironwall/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0857" Value="Friendship/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0858" Value="Satiated/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0859" Value="Stonethrower/Handicraft Jewel 4"/>
+        <handlers:Item Key="item085A" Value="Resistor/Handicraft Jewel 4"/>
+        <handlers:Item Key="item085B" Value="Flight/Handicraft Jewel 4"/>
+        <handlers:Item Key="item085C" Value="Sprinter/Handicraft Jewel 4"/>
+        <handlers:Item Key="item085D" Value="Refresh/Handicraft Jewel 4"/>
+        <handlers:Item Key="item085E" Value="Jumping/Handicraft Jewel 4"/>
+        <handlers:Item Key="item085F" Value="Sheath/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0860" Value="Gobbler/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0861" Value="Grinder/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0862" Value="Bomber/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0863" Value="Fungiform/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0864" Value="Slider/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0865" Value="Guardian/Handicraft Jewel 4"/>
+        <handlers:Item Key="item0866" Value="Footing/Protection Jewel 4"/>
+        <handlers:Item Key="item0867" Value="Charger/Protection Jewel 4"/>
+        <handlers:Item Key="item0868" Value="Enhancer/Protection Jewel 4"/>
+        <handlers:Item Key="item0869" Value="Destroyer/Protection Jewel 4"/>
+        <handlers:Item Key="item086A" Value="KO/Protection Jewel 4"/>
+        <handlers:Item Key="item086B" Value="Potential/Protection Jewel 4"/>
+        <handlers:Item Key="item086C" Value="Wind Resist/Protection Jewel 4"/>
+        <handlers:Item Key="item086D" Value="Draw/Protection Jewel 4"/>
+        <handlers:Item Key="item086E" Value="Throttle/Protection Jewel 4"/>
+        <handlers:Item Key="item086F" Value="Challenger/Protection Jewel 4"/>
+        <handlers:Item Key="item0870" Value="Flawless/Protection Jewel 4"/>
+        <handlers:Item Key="item0871" Value="Furor/Protection Jewel 4"/>
+        <handlers:Item Key="item0872" Value="Mighty/Protection Jewel 4"/>
+        <handlers:Item Key="item0873" Value="Brace/Protection Jewel 4"/>
+        <handlers:Item Key="item0874" Value="Phoenix/Protection Jewel 4"/>
+        <handlers:Item Key="item0875" Value="Earplug/Protection Jewel 4"/>
+        <handlers:Item Key="item0876" Value="Critical/Protection Jewel 4"/>
+        <handlers:Item Key="item0877" Value="Tenderizer/Protection Jewel 4"/>
+        <handlers:Item Key="item0878" Value="Handicraft/Protection Jewel 4"/>
+        <handlers:Item Key="item0879" Value="Release/Protection Jewel 4"/>
+        <handlers:Item Key="item087A" Value="Footing/Medicine Jewel 4"/>
+        <handlers:Item Key="item087B" Value="Charger/Medicine Jewel 4"/>
+        <handlers:Item Key="item087C" Value="Enhancer/Medicine Jewel 4"/>
+        <handlers:Item Key="item087D" Value="Destroyer/Medicine Jewel 4"/>
+        <handlers:Item Key="item087E" Value="KO/Medicine Jewel 4"/>
+        <handlers:Item Key="item087F" Value="Potential/Medicine Jewel 4"/>
+        <handlers:Item Key="item0880" Value="Wind Resist/Medicine Jewel 4"/>
+        <handlers:Item Key="item0881" Value="Draw/Medicine Jewel 4"/>
+        <handlers:Item Key="item0882" Value="Throttle/Medicine Jewel 4"/>
+        <handlers:Item Key="item0883" Value="Challenger/Medicine Jewel 4"/>
+        <handlers:Item Key="item0884" Value="Flawless/Medicine Jewel 4"/>
+        <handlers:Item Key="item0885" Value="Furor/Medicine Jewel 4"/>
+        <handlers:Item Key="item0886" Value="Mighty/Medicine Jewel 4"/>
+        <handlers:Item Key="item0887" Value="Brace/Medicine Jewel 4"/>
+        <handlers:Item Key="item0888" Value="Phoenix/Medicine Jewel 4"/>
+        <handlers:Item Key="item0889" Value="Earplug/Medicine Jewel 4"/>
+        <handlers:Item Key="item088A" Value="Critical/Medicine Jewel 4"/>
+        <handlers:Item Key="item088B" Value="Tenderizer/Medicine Jewel 4"/>
+        <handlers:Item Key="item088C" Value="Handicraft/Medicine Jewel 4"/>
+        <handlers:Item Key="item088D" Value="Release/Medicine Jewel 4"/>
+        <handlers:Item Key="item088E" Value="Footing/Vitality Jewel 4"/>
+        <handlers:Item Key="item088F" Value="Charger/Vitality Jewel 4"/>
+        <handlers:Item Key="item0890" Value="Enhancer/Vitality Jewel 4"/>
+        <handlers:Item Key="item0891" Value="Destroyer/Vitality Jewel 4"/>
+        <handlers:Item Key="item0892" Value="KO/Vitality Jewel 4"/>
+        <handlers:Item Key="item0893" Value="Potential/Vitality Jewel 4"/>
+        <handlers:Item Key="item0894" Value="Wind Resist/Vitality Jewel 4"/>
+        <handlers:Item Key="item0895" Value="Draw/Vitality Jewel 4"/>
+        <handlers:Item Key="item0896" Value="Throttle/Vitality Jewel 4"/>
+        <handlers:Item Key="item0897" Value="Challenger/Vitality Jewel 4"/>
+        <handlers:Item Key="item0898" Value="Flawless/Vitality Jewel 4"/>
+        <handlers:Item Key="item0899" Value="Furor/Vitality Jewel 4"/>
+        <handlers:Item Key="item089A" Value="Mighty/Vitality Jewel 4"/>
+        <handlers:Item Key="item089B" Value="Brace/Vitality Jewel 4"/>
+        <handlers:Item Key="item089C" Value="Phoenix/Vitality Jewel 4"/>
+        <handlers:Item Key="item089D" Value="Earplug/Vitality Jewel 4"/>
+        <handlers:Item Key="item089E" Value="Critical/Vitality Jewel 4"/>
+        <handlers:Item Key="item089F" Value="Tenderizer/Vitality Jewel 4"/>
+        <handlers:Item Key="item08A0" Value="Handicraft/Vitality Jewel 4"/>
+        <handlers:Item Key="item08A1" Value="Release/Vitality Jewel 4"/>
+        <handlers:Item Key="item08A2" Value="Footing/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08A3" Value="Charger/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08A4" Value="Enhancer/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08A5" Value="Destroyer/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08A6" Value="KO/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08A7" Value="Potential/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08A8" Value="Wind Resist/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08A9" Value="Draw/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08AA" Value="Throttle/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08AB" Value="Challenger/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08AC" Value="Flawless/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08AD" Value="Furor/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08AE" Value="Mighty/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08AF" Value="Brace/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08B0" Value="Phoenix/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08B1" Value="Earplug/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08B2" Value="Critical/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08B3" Value="Tenderizer/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08B4" Value="Handicraft/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08B5" Value="Release/Maintenance Jewel 4"/>
+        <handlers:Item Key="item08B6" Value="Footing/Physique Jewel 4"/>
+        <handlers:Item Key="item08B7" Value="Charger/Physique Jewel 4"/>
+        <handlers:Item Key="item08B8" Value="Enhancer/Physique Jewel 4"/>
+        <handlers:Item Key="item08B9" Value="Destroyer/Physique Jewel 4"/>
+        <handlers:Item Key="item08BA" Value="KO/Physique Jewel 4"/>
+        <handlers:Item Key="item08BB" Value="Potential/Physique Jewel 4"/>
+        <handlers:Item Key="item08BC" Value="Wind Resist/Physique Jewel 4"/>
+        <handlers:Item Key="item08BD" Value="Draw/Physique Jewel 4"/>
+        <handlers:Item Key="item08BE" Value="Throttle/Physique Jewel 4"/>
+        <handlers:Item Key="item08BF" Value="Challenger/Physique Jewel 4"/>
+        <handlers:Item Key="item08C0" Value="Flawless/Physique Jewel 4"/>
+        <handlers:Item Key="item08C1" Value="Furor/Physique Jewel 4"/>
+        <handlers:Item Key="item08C2" Value="Mighty/Physique Jewel 4"/>
+        <handlers:Item Key="item08C3" Value="Brace/Physique Jewel 4"/>
+        <handlers:Item Key="item08C4" Value="Phoenix/Physique Jewel 4"/>
+        <handlers:Item Key="item08C5" Value="Earplug/Physique Jewel 4"/>
+        <handlers:Item Key="item08C6" Value="Critical/Physique Jewel 4"/>
+        <handlers:Item Key="item08C7" Value="Tenderizer/Physique Jewel 4"/>
+        <handlers:Item Key="item08C8" Value="Handicraft/Physique Jewel 4"/>
+        <handlers:Item Key="item08C9" Value="Release/Physique Jewel 4"/>
+        <handlers:Item Key="item08CA" Value="Footing/Evasion Jewel 4"/>
+        <handlers:Item Key="item08CB" Value="Charger/Evasion Jewel 4"/>
+        <handlers:Item Key="item08CC" Value="Enhancer/Evasion Jewel 4"/>
+        <handlers:Item Key="item08CD" Value="Destroyer/Evasion Jewel 4"/>
+        <handlers:Item Key="item08CE" Value="KO/Evasion Jewel 4"/>
+        <handlers:Item Key="item08CF" Value="Potential/Evasion Jewel 4"/>
+        <handlers:Item Key="item08D0" Value="Wind Resist/Evasion Jewel 4"/>
+        <handlers:Item Key="item08D1" Value="Draw/Evasion Jewel 4"/>
+        <handlers:Item Key="item08D2" Value="Throttle/Evasion Jewel 4"/>
+        <handlers:Item Key="item08D3" Value="Challenger/Evasion Jewel 4"/>
+        <handlers:Item Key="item08D4" Value="Flawless/Evasion Jewel 4"/>
+        <handlers:Item Key="item08D5" Value="Furor/Evasion Jewel 4"/>
+        <handlers:Item Key="item08D6" Value="Mighty/Evasion Jewel 4"/>
+        <handlers:Item Key="item08D7" Value="Brace/Evasion Jewel 4"/>
+        <handlers:Item Key="item08D8" Value="Phoenix/Evasion Jewel 4"/>
+        <handlers:Item Key="item08D9" Value="Earplug/Evasion Jewel 4"/>
+        <handlers:Item Key="item08DA" Value="Critical/Evasion Jewel 4"/>
+        <handlers:Item Key="item08DB" Value="Tenderizer/Evasion Jewel 4"/>
+        <handlers:Item Key="item08DC" Value="Handicraft/Evasion Jewel 4"/>
+        <handlers:Item Key="item08DD" Value="Release/Evasion Jewel 4"/>
+        <handlers:Item Key="item08DE" Value="Survival Jewel 1"/>
+        <handlers:Item Key="item08DF" Value="Item 2271"/>
+        <handlers:Item Key="item08E0" Value="Warming Jewel 2"/>
+        <handlers:Item Key="item08E1" Value="Item 2273"/>
+        <handlers:Item Key="item08E2" Value="Item 2274"/>
+        <handlers:Item Key="item08E3" Value="Item 2275"/>
+        <handlers:Item Key="item08E4" Value="Item 2276"/>
+        <handlers:Item Key="item08E5" Value="Item 2277"/>
+        <handlers:Item Key="item08E6" Value="Item 2278"/>
+        <handlers:Item Key="item08E7" Value="Item 2279"/>
+        <handlers:Item Key="item08E8" Value="Item 2280"/>
+        <handlers:Item Key="item08E9" Value="Item 2281"/>
+        <handlers:Item Key="item08EA" Value="Item 2282"/>
+        <handlers:Item Key="item08EB" Value="Item 2283"/>
+        <handlers:Item Key="item08EC" Value="Item 2284"/>
+        <handlers:Item Key="item08ED" Value="Item 2285"/>
+        <handlers:Item Key="item08EE" Value="Item 2286"/>
+        <handlers:Item Key="item08EF" Value="Item 2287"/>
+        <handlers:Item Key="item08F0" Value="Item 2288"/>
+        <handlers:Item Key="item08F1" Value="Item 2289"/>
+        <handlers:Item Key="item08F2" Value="Item 2290"/>
+        <handlers:Item Key="item08F3" Value="Item 2291"/>
+        <handlers:Item Key="item08F4" Value="Item 2292"/>
+        <handlers:Item Key="item08F5" Value="Item 2293"/>
+        <handlers:Item Key="item08F6" Value="Item 2294"/>
+        <handlers:Item Key="item08F7" Value="Item 2295"/>
+        <handlers:Item Key="item08F8" Value="Item 2296"/>
+        <handlers:Item Key="item08F9" Value="Item 2297"/>
+        <handlers:Item Key="item08FA" Value="Item 2298"/>
+        <handlers:Item Key="item08FB" Value="Item 2299"/>
+        <handlers:Item Key="item08FC" Value="Item 2300"/>
+        <handlers:Item Key="item08FD" Value="Item 2301"/>
+        <handlers:Item Key="item08FE" Value="Item 2302"/>
+        <handlers:Item Key="item08FF" Value="Item 2303"/>
+        <handlers:Item Key="item0900" Value="Item 2304"/>
+        <handlers:Item Key="item0901" Value="Item 2305"/>
+        <handlers:Item Key="item0902" Value="Item 2306"/>
+        <handlers:Item Key="item0903" Value="Item 2307"/>
+        <handlers:Item Key="item0904" Value="Item 2308"/>
+        <handlers:Item Key="item0905" Value="Item 2309"/>
+        <handlers:Item Key="item0906" Value="Item 2310"/>
+        <handlers:Item Key="item0907" Value="Item 2311"/>
+        <handlers:Item Key="item0908" Value="Item 2312"/>
+        <handlers:Item Key="item0909" Value="Item 2313"/>
+        <handlers:Item Key="item090A" Value="Item 2314"/>
+        <handlers:Item Key="item090B" Value="Item 2315"/>
+        <handlers:Item Key="item090C" Value="Item 2316"/>
+        <handlers:Item Key="item090D" Value="Item 2317"/>
+        <handlers:Item Key="item090E" Value="Item 2318"/>
+        <handlers:Item Key="item090F" Value="Item 2319"/>
+        <handlers:Item Key="item0910" Value="Item 2320"/>
+        <handlers:Item Key="item0911" Value="Item 2321"/>
+        <handlers:Item Key="item0912" Value="Item 2322"/>
+        <handlers:Item Key="item0913" Value="Item 2323"/>
+        <handlers:Item Key="item0914" Value="Item 2324"/>
+        <handlers:Item Key="item0915" Value="Item 2325"/>
+        <handlers:Item Key="item0916" Value="Item 2326"/>
+        <handlers:Item Key="item0917" Value="Item 2327"/>
+        <handlers:Item Key="item0918" Value="Item 2328"/>
+        <handlers:Item Key="item0919" Value="Item 2329"/>
+        <handlers:Item Key="item091A" Value="Item 2330"/>
+        <handlers:Item Key="item091B" Value="Item 2331"/>
+        <handlers:Item Key="item091C" Value="Item 2332"/>
+        <handlers:Item Key="item091D" Value="Item 2333"/>
+        <handlers:Item Key="item091E" Value="Item 2334"/>
+        <handlers:Item Key="item091F" Value="Item 2335"/>
+        <handlers:Item Key="item0920" Value="Item 2336"/>
+        <handlers:Item Key="item0921" Value="Item 2337"/>
+        <handlers:Item Key="item0922" Value="Item 2338"/>
+        <handlers:Item Key="item0923" Value="Item 2339"/>
+        <handlers:Item Key="item0924" Value="Item 2340"/>
+        <handlers:Item Key="item0925" Value="Item 2341"/>
+        <handlers:Item Key="item0926" Value="Item 2342"/>
+        <handlers:Item Key="item0927" Value="Item 2343"/>
+        <handlers:Item Key="item0928" Value="Item 2344"/>
+        <handlers:Item Key="item0929" Value="Item 2345"/>
+        <handlers:Item Key="item092A" Value="Item 2346"/>
+        <handlers:Item Key="item092B" Value="Item 2347"/>
+        <handlers:Item Key="item092C" Value="Item 2348"/>
+        <handlers:Item Key="item092D" Value="Item 2349"/>
+        <handlers:Item Key="item092E" Value="Item 2350"/>
+        <handlers:Item Key="item092F" Value="Item 2351"/>
+        <handlers:Item Key="item0930" Value="Item 2352"/>
+        <handlers:Item Key="item0931" Value="Item 2353"/>
+        <handlers:Item Key="item0932" Value="Item 2354"/>
+        <handlers:Item Key="item0933" Value="Item 2355"/>
+        <handlers:Item Key="item0934" Value="Item 2356"/>
+        <handlers:Item Key="item0935" Value="Item 2357"/>
+        <handlers:Item Key="item0936" Value="Item 2358"/>
+        <handlers:Item Key="item0937" Value="Item 2359"/>
+        <handlers:Item Key="item0938" Value="Item 2360"/>
+        <handlers:Item Key="item0939" Value="Item 2361"/>
+        <handlers:Item Key="item093A" Value="Item 2362"/>
+        <handlers:Item Key="item093B" Value="Item 2363"/>
+        <handlers:Item Key="item093C" Value="Item 2364"/>
+        <handlers:Item Key="item093D" Value="Item 2365"/>
+        <handlers:Item Key="item093E" Value="Item 2366"/>
+        <handlers:Item Key="item093F" Value="Item 2367"/>
+        <handlers:Item Key="item0940" Value="Item 2368"/>
+        <handlers:Item Key="item0941" Value="Item 2369"/>
+        <handlers:Item Key="item0942" Value="Item 2370"/>
+        <handlers:Item Key="item0943" Value="Item 2371"/>
+        <handlers:Item Key="item0944" Value="Item 2372"/>
+        <handlers:Item Key="item0945" Value="Item 2373"/>
+        <handlers:Item Key="item0946" Value="Item 2374"/>
+        <handlers:Item Key="item0947" Value="Item 2375"/>
+        <handlers:Item Key="item0948" Value="Item 2376"/>
+        <handlers:Item Key="item0949" Value="Item 2377"/>
+        <handlers:Item Key="item094A" Value="Item 2378"/>
+        <handlers:Item Key="item094B" Value="Item 2379"/>
+        <handlers:Item Key="item094C" Value="Item 2380"/>
+        <handlers:Item Key="item094D" Value="Item 2381"/>
+        <handlers:Item Key="item094E" Value="Item 2382"/>
+        <handlers:Item Key="item094F" Value="Item 2383"/>
+        <handlers:Item Key="item0950" Value="Item 2384"/>
+        <handlers:Item Key="item0951" Value="Item 2385"/>
+        <handlers:Item Key="item0952" Value="Item 2386"/>
+        <handlers:Item Key="item0953" Value="Item 2387"/>
+        <handlers:Item Key="item0954" Value="Item 2388"/>
+        <handlers:Item Key="item0955" Value="Item 2389"/>
+        <handlers:Item Key="item0956" Value="Item 2390"/>
+        <handlers:Item Key="item0957" Value="Item 2391"/>
+        <handlers:Item Key="item0958" Value="Item 2392"/>
+        <handlers:Item Key="item0959" Value="Item 2393"/>
+        <handlers:Item Key="item095A" Value="Item 2394"/>
+        <handlers:Item Key="item095B" Value="Item 2395"/>
+        <handlers:Item Key="item095C" Value="Item 2396"/>
+        <handlers:Item Key="item095D" Value="Item 2397"/>
+        <handlers:Item Key="item095E" Value="Item 2398"/>
+        <handlers:Item Key="item095F" Value="Item 2399"/>
+        <handlers:Item Key="item0960" Value="Item 2400"/>
+        <handlers:Item Key="item0961" Value="Item 2401"/>
+        <handlers:Item Key="item0962" Value="Item 2402"/>
+        <handlers:Item Key="item0963" Value="Item 2403"/>
+        <handlers:Item Key="item0964" Value="Item 2404"/>
+        <handlers:Item Key="item0965" Value="Item 2405"/>
+        <handlers:Item Key="item0966" Value="Item 2406"/>
+        <handlers:Item Key="item0967" Value="Item 2407"/>
+        <handlers:Item Key="item0968" Value="Item 2408"/>
+        <handlers:Item Key="item0969" Value="Item 2409"/>
+        <handlers:Item Key="item096A" Value="Item 2410"/>
+        <handlers:Item Key="item096B" Value="Item 2411"/>
+        <handlers:Item Key="item096C" Value="Item 2412"/>
+        <handlers:Item Key="item096D" Value="Plum Flower Pot"/>
+        <handlers:Item Key="item096E" Value="Decorative Tree"/>
+        <handlers:Item Key="item096F" Value="Item 2415"/>
+        <handlers:Item Key="item0970" Value="Item 2416"/>
+        <handlers:Item Key="item0971" Value="Item 2417"/>
+        <handlers:Item Key="item0972" Value="Item 2418"/>
+        <handlers:Item Key="item0973" Value="Item 2419"/>
+        <handlers:Item Key="item0974" Value="Item 2420"/>
+        <handlers:Item Key="item0975" Value="Item 2421"/>
+        <handlers:Item Key="item0976" Value="Item 2422"/>
+        <handlers:Item Key="item0977" Value="Item 2423"/>
+        <handlers:Item Key="item0978" Value="Item 2424"/>
+        <handlers:Item Key="item0979" Value="Item 2425"/>
+        <handlers:Item Key="item097A" Value="Item 2426"/>
+        <handlers:Item Key="item097B" Value="Item 2427"/>
+        <handlers:Item Key="item097C" Value="Item 2428"/>
+        <handlers:Item Key="item097D" Value="Item 2429"/>
+        <handlers:Item Key="item097E" Value="Felyne Balloon"/>
+        <handlers:Item Key="item097F" Value="Grimalkyne Balloon (White)"/>
+        <handlers:Item Key="item0980" Value="Grimalkyne Balloon (Black)"/>
+        <handlers:Item Key="item0981" Value="Gajalaka Balloon"/>
+        <handlers:Item Key="item0982" Value="Item 2434"/>
+        <handlers:Item Key="item0983" Value="Item 2435"/>
+        <handlers:Item Key="item0984" Value="Item 2436"/>
+        <handlers:Item Key="item0985" Value="Item 2437"/>
+        <handlers:Item Key="item0986" Value="Item 2438"/>
+        <handlers:Item Key="item0987" Value="Item 2439"/>
+        <handlers:Item Key="item0988" Value="Item 2440"/>
+        <handlers:Item Key="item0989" Value="Item 2441"/>
+        <handlers:Item Key="item098A" Value="Item 2442"/>
+        <handlers:Item Key="item098B" Value="Item 2443"/>
+        <handlers:Item Key="item098C" Value="Item 2444"/>
+        <handlers:Item Key="item098D" Value="Item 2445"/>
+        <handlers:Item Key="item098E" Value="Item 2446"/>
+        <handlers:Item Key="item098F" Value="Item 2447"/>
+        <handlers:Item Key="item0990" Value="Item 2448"/>
+        <handlers:Item Key="item0991" Value="Item 2449"/>
+        <handlers:Item Key="item0992" Value="Item 2450"/>
+        <handlers:Item Key="item0993" Value="Item 2451"/>
+        <handlers:Item Key="item0994" Value="Item 2452"/>
+        <handlers:Item Key="item0995" Value="Item 2453"/>
+        <handlers:Item Key="item0996" Value="Item 2454"/>
+        <handlers:Item Key="item0997" Value="Joyful Lanterns"/>
+        <handlers:Item Key="item0998" Value="Sky Lantern Lights"/>
+        <handlers:Item Key="item0999" Value="Item 2457"/>
+        <handlers:Item Key="item099A" Value="Item 2458"/>
+        <handlers:Item Key="item099B" Value="Item 2459"/>
+        <handlers:Item Key="item099C" Value="Item 2460"/>
+        <handlers:Item Key="item099D" Value="Item 2461"/>
+        <handlers:Item Key="item099E" Value="Item 2462"/>
+        <handlers:Item Key="item099F" Value="Item 2463"/>
+        <handlers:Item Key="item09A0" Value="Item 2464"/>
+        <handlers:Item Key="item09A1" Value="Item 2465"/>
+        <handlers:Item Key="item09A2" Value="Item 2466"/>
+        <handlers:Item Key="item09A3" Value="Item 2467"/>
+        <handlers:Item Key="item09A4" Value="Item 2468"/>
+        <handlers:Item Key="item09A5" Value="Item 2469"/>
+        <handlers:Item Key="item09A6" Value="Item 2470"/>
+        <handlers:Item Key="item09A7" Value="Item 2471"/>
+        <handlers:Item Key="item09A8" Value="Item 2472"/>
+        <handlers:Item Key="item09A9" Value="Item 2473"/>
+        <handlers:Item Key="item09AA" Value="Paper Lantern"/>
+        <handlers:Item Key="item09AB" Value="Item 2475"/>
+        <handlers:Item Key="item09AC" Value="Round Paper Lanterns"/>
+        <handlers:Item Key="item09AD" Value="Item 2477"/>
+        <handlers:Item Key="item09AE" Value="Item 2478"/>
+        <handlers:Item Key="item09AF" Value="Item 2479"/>
+        <handlers:Item Key="item09B0" Value="Item 2480"/>
+        <handlers:Item Key="item09B1" Value="Item 2481"/>
+        <handlers:Item Key="item09B2" Value="Item 2482"/>
+        <handlers:Item Key="item09B3" Value="Item 2483"/>
+        <handlers:Item Key="item09B4" Value="Item 2484"/>
+        <handlers:Item Key="item09B5" Value="Item 2485"/>
+        <handlers:Item Key="item09B6" Value="Item 2486"/>
+        <handlers:Item Key="item09B7" Value="Item 2487"/>
+        <handlers:Item Key="item09B8" Value="Item 2488"/>
+        <handlers:Item Key="item09B9" Value="Item 2489"/>
+        <handlers:Item Key="item09BA" Value="Item 2490"/>
+        <handlers:Item Key="item09BB" Value="Item 2491"/>
+        <handlers:Item Key="item09BC" Value="Item 2492"/>
+        <handlers:Item Key="item09BD" Value="Item 2493"/>
+        <handlers:Item Key="item09BE" Value="Item 2494"/>
+        <handlers:Item Key="item09BF" Value="Item 2495"/>
+        <handlers:Item Key="item09C0" Value="Item 2496"/>
+        <handlers:Item Key="item09C1" Value="Item 2497"/>
+        <handlers:Item Key="item09C2" Value="Item 2498"/>
+        <handlers:Item Key="item09C3" Value="Item 2499"/>
+        <handlers:Item Key="item09C4" Value="Item 2500"/>
+        <handlers:Item Key="item09C5" Value="Item 2501"/>
+        <handlers:Item Key="item09C6" Value="Item 2502"/>
+        <handlers:Item Key="item09C7" Value="Item 2503"/>
+        <handlers:Item Key="item09C8" Value="Item 2504"/>
+        <handlers:Item Key="item09C9" Value="Item 2505"/>
+        <handlers:Item Key="item09CA" Value="Item 2506"/>
+        <handlers:Item Key="item09CB" Value="Item 2507"/>
+        <handlers:Item Key="item09CC" Value="Item 2508"/>
+        <handlers:Item Key="item09CD" Value="Item 2509"/>
+        <handlers:Item Key="item09CE" Value="Item 2510"/>
+        <handlers:Item Key="item09CF" Value="Item 2511"/>
+        <handlers:Item Key="item09D0" Value="Item 2512"/>
+        <handlers:Item Key="item09D1" Value="Item 2513"/>
+        <handlers:Item Key="item09D2" Value="Item 2514"/>
+        <handlers:Item Key="item09D3" Value="Item 2515"/>
+        <handlers:Item Key="item09D4" Value="Item 2516"/>
+        <handlers:Item Key="item09D5" Value="Item 2517"/>
+        <handlers:Item Key="item09D6" Value="Item 2518"/>
+        <handlers:Item Key="item09D7" Value="Item 2519"/>
+        <handlers:Item Key="item09D8" Value="Item 2520"/>
+        <handlers:Item Key="item09D9" Value="Item 2521"/>
+        <handlers:Item Key="item09DA" Value="Item 2522"/>
+        <handlers:Item Key="item09DB" Value="Item 2523"/>
+        <handlers:Item Key="item09DC" Value="Item 2524"/>
+        <handlers:Item Key="item09DD" Value="Item 2525"/>
+        <handlers:Item Key="item09DE" Value="Item 2526"/>
+        <handlers:Item Key="item09DF" Value="Item 2527"/>
+        <handlers:Item Key="item09E0" Value="Item 2528"/>
+        <handlers:Item Key="item09E1" Value="Item 2529"/>
+        <handlers:Item Key="item09E2" Value="Joyful Platter"/>
+        <handlers:Item Key="item09E3" Value="Luxury Platter"/>
+        <handlers:Item Key="item09E4" Value="Item 2532"/>
+        <handlers:Item Key="item09E5" Value="Item 2533"/>
+        <handlers:Item Key="item09E6" Value="Item 2534"/>
+        <handlers:Item Key="item09E7" Value="Item 2535"/>
+        <handlers:Item Key="item09E8" Value="Item 2536"/>
+        <handlers:Item Key="item09E9" Value="Item 2537"/>
+        <handlers:Item Key="item09EA" Value="Item 2538"/>
+        <handlers:Item Key="item09EB" Value="Item 2539"/>
+        <handlers:Item Key="item09EC" Value="Item 2540"/>
+        <handlers:Item Key="item09ED" Value="Item 2541"/>
+        <handlers:Item Key="item09EE" Value="Item 2542"/>
+        <handlers:Item Key="item09EF" Value="Item 2543"/>
+        <handlers:Item Key="item09F0" Value="Item 2544"/>
+        <handlers:Item Key="item09F1" Value="Item 2545"/>
+        <handlers:Item Key="item09F2" Value="Item 2546"/>
+        <handlers:Item Key="item09F3" Value="Item 2547"/>
+        <handlers:Item Key="item09F4" Value="Item 2548"/>
+        <handlers:Item Key="item09F5" Value="Item 2549"/>
+        <handlers:Item Key="item09F6" Value="Item 2550"/>
+        <handlers:Item Key="item09F7" Value="Item 2551"/>
+        <handlers:Item Key="item09F8" Value="Item 2552"/>
+        <handlers:Item Key="item09F9" Value="Item 2553"/>
+        <handlers:Item Key="item09FA" Value="Item 2554"/>
+        <handlers:Item Key="item09FB" Value="Item 2555"/>
+        <handlers:Item Key="item09FC" Value="Item 2556"/>
+        <handlers:Item Key="item09FD" Value="Item 2557"/>
+        <handlers:Item Key="item09FE" Value="Item 2558"/>
+        <handlers:Item Key="item09FF" Value="Item 2559"/>
+        <handlers:Item Key="item0A00" Value="Item 2560"/>
+        <handlers:Item Key="item0A01" Value="Item 2561"/>
+        <handlers:Item Key="item0A02" Value="Item 2562"/>
+        <handlers:Item Key="item0A03" Value="Item 2563"/>
+        <handlers:Item Key="item0A04" Value="Item 2564"/>
+        <handlers:Item Key="item0A05" Value="Item 2565"/>
+        <handlers:Item Key="item0A06" Value="Item 2566"/>
+        <handlers:Item Key="item0A07" Value="Item 2567"/>
+        <handlers:Item Key="item0A08" Value="Item 2568"/>
+        <handlers:Item Key="item0A09" Value="Item 2569"/>
+        <handlers:Item Key="item0A0A" Value="Item 2570"/>
+        <handlers:Item Key="item0A0B" Value="Item 2571"/>
+        <handlers:Item Key="item0A0C" Value="Item 2572"/>
+        <handlers:Item Key="item0A0D" Value="Item 2573"/>
+        <handlers:Item Key="item0A0E" Value="Item 2574"/>
+        <handlers:Item Key="item0A0F" Value="Item 2575"/>
+        <handlers:Item Key="item0A10" Value="Item 2576"/>
+        <handlers:Item Key="item0A11" Value="Item 2577"/>
+        <handlers:Item Key="item0A12" Value="Item 2578"/>
+        <handlers:Item Key="item0A13" Value="Item 2579"/>
+        <handlers:Item Key="item0A14" Value="Item 2580"/>
+        <handlers:Item Key="item0A15" Value="Joyful Snowman"/>
+        <handlers:Item Key="item0A16" Value="Appreciative Snowman"/>
+        <handlers:Item Key="item0A17" Value="Item 2583"/>
+        <handlers:Item Key="item0A18" Value="Item 2584"/>
+        <handlers:Item Key="item0A19" Value="Item 2585"/>
+        <handlers:Item Key="item0A1A" Value="Sky Lanterns"/>
+        <handlers:Item Key="item0A1B" Value="Item 2587"/>
+        <handlers:Item Key="item0A1C" Value="Item 2588"/>
+        <handlers:Item Key="item0A1D" Value="Item 2589"/>
+        <handlers:Item Key="item0A1E" Value="Item 2590"/>
+        <handlers:Item Key="item0A1F" Value="Item 2591"/>
+        <handlers:Item Key="item0A20" Value="Item 2592"/>
+        <handlers:Item Key="item0A21" Value="Item 2593"/>
+        <handlers:Item Key="item0A22" Value="Item 2594"/>
+        <handlers:Item Key="item0A23" Value="Masterpiece Sketches"/>
+        <handlers:Item Key="item0A24" Value="Item 2596"/>
+        <handlers:Item Key="item0A25" Value="Item 2597"/>
+        <handlers:Item Key="item0A26" Value="Item 2598"/>
+        <handlers:Item Key="item0A27" Value="Item 2599"/>
+        <handlers:Item Key="item0A28" Value="Item 2600"/>
+        <handlers:Item Key="item0A29" Value="Item 2601"/>
+        <handlers:Item Key="item0A2A" Value="Item 2602"/>
+        <handlers:Item Key="item0A2B" Value="Item 2603"/>
+        <handlers:Item Key="item0A2C" Value="Item 2604"/>
+        <handlers:Item Key="item0A2D" Value="Item 2605"/>
+        <handlers:Item Key="item0A2E" Value="Item 2606"/>
+        <handlers:Item Key="item0A2F" Value="Item 2607"/>
+        <handlers:Item Key="item0A30" Value="Item 2608"/>
+        <handlers:Item Key="item0A31" Value="Item 2609"/>
+        <handlers:Item Key="item0A32" Value="Item 2610"/>
+        <handlers:Item Key="item0A33" Value="Item 2611"/>
+        <handlers:Item Key="item0A34" Value="Item 2612"/>
+        <handlers:Item Key="item0A35" Value="Item 2613"/>
+        <handlers:Item Key="item0A36" Value="Item 2614"/>
+        <handlers:Item Key="item0A37" Value="Item 2615"/>
+        <handlers:Item Key="item0A38" Value="Item 2616"/>
+        <handlers:Item Key="item0A39" Value="Item 2617"/>
+        <handlers:Item Key="item0A3A" Value="Item 2618"/>
+        <handlers:Item Key="item0A3B" Value="Item 2619"/>
+        <handlers:Item Key="item0A3C" Value="Item 2620"/>
+        <handlers:Item Key="item0A3D" Value="Item 2621"/>
+        <handlers:Item Key="item0A3E" Value="Item 2622"/>
+        <handlers:Item Key="item0A3F" Value="Item 2623"/>
+        <handlers:Item Key="item0A40" Value="Item 2624"/>
+        <handlers:Item Key="item0A41" Value="Item 2625"/>
+        <handlers:Item Key="item0A42" Value="Item 2626"/>
+        <handlers:Item Key="item0A43" Value="Item 2627"/>
+        <handlers:Item Key="item0A44" Value="Item 2628"/>
+        <handlers:Item Key="item0A45" Value="Item 2629"/>
+        <handlers:Item Key="item0A46" Value="Item 2630"/>
+        <handlers:Item Key="item0A47" Value="Item 2631"/>
+        <handlers:Item Key="item0A48" Value="Item 2632"/>
+        <handlers:Item Key="item0A49" Value="Item 2633"/>
+        <handlers:Item Key="item0A4A" Value="Item 2634"/>
+        <handlers:Item Key="item0A4B" Value="Item 2635"/>
+        <handlers:Item Key="item0A4C" Value="Item 2636"/>
+        <handlers:Item Key="item0A4D" Value="Item 2637"/>
+        <handlers:Item Key="item0A4E" Value="Item 2638"/>
+        <handlers:Item Key="item0A4F" Value="Item 2639"/>
+        <handlers:Item Key="item0A50" Value="Item 2640"/>
+        <handlers:Item Key="item0A51" Value="Item 2641"/>
+        <handlers:Item Key="item0A52" Value="Item 2642"/>
+        <handlers:Item Key="item0A53" Value="Item 2643"/>
+        <handlers:Item Key="item0A54" Value="Item 2644"/>
+        <handlers:Item Key="item0A55" Value="Item 2645"/>
+        <handlers:Item Key="item0A56" Value="Item 2646"/>
+        <handlers:Item Key="item0A57" Value="Item 2647"/>
+        <handlers:Item Key="item0A58" Value="Item 2648"/>
+        <handlers:Item Key="item0A59" Value="Item 2649"/>
+        <handlers:Item Key="item0A5A" Value="Item 2650"/>
+        <handlers:Item Key="item0A5B" Value="Item 2651"/>
+        <handlers:Item Key="item0A5C" Value="Item 2652"/>
+        <handlers:Item Key="item0A5D" Value="Item 2653"/>
+        <handlers:Item Key="item0A5E" Value="Item 2654"/>
+        <handlers:Item Key="item0A5F" Value="Item 2655"/>
+        <handlers:Item Key="item0A60" Value="Item 2656"/>
+        <handlers:Item Key="item0A61" Value="Item 2657"/>
+        <handlers:Item Key="item0A62" Value="Item 2658"/>
+        <handlers:Item Key="item0A63" Value="Item 2659"/>
+        <handlers:Item Key="item0A64" Value="Item 2660"/>
+        <handlers:Item Key="item0A65" Value="Item 2661"/>
+        <handlers:Item Key="item0A66" Value="Item 2662"/>
+        <handlers:Item Key="item0A67" Value="Item 2663"/>
+        <handlers:Item Key="item0A68" Value="Item 2664"/>
+        <handlers:Item Key="item0A69" Value="Item 2665"/>
+        <handlers:Item Key="item0A6A" Value="Item 2666"/>
+        <handlers:Item Key="item0A6B" Value="Item 2667"/>
+        <handlers:Item Key="item0A6C" Value="Item 2668"/>
+        <handlers:Item Key="item0A6D" Value="Item 2669"/>
+        <handlers:Item Key="item0A6E" Value="Item 2670"/>
+        <handlers:Item Key="item0A6F" Value="Item 2671"/>
+        <handlers:Item Key="item0A70" Value="Item 2672"/>
+        <handlers:Item Key="item0A71" Value="Item 2673"/>
+        <handlers:Item Key="item0A72" Value="Item 2674"/>
+        <handlers:Item Key="item0A73" Value="レイトウチケット"/>
+        <handlers:Item Key="item0A74" Value="Pearlspring Ticket"/>
+        <handlers:Item Key="item0A75" Value="雪玉"/>
+        <handlers:Item Key="item0A76" Value="雪だるま"/>
+        <handlers:Item Key="item0A77" Value="Item 2679"/>
+        <handlers:Item Key="item0A78" Value="Item 2680"/>
+        <handlers:Item Key="item0A79" Value="Item 2681"/>
+        <handlers:Item Key="item0A7A" Value="Item 2682"/>
+        <handlers:Item Key="item0A7B" Value="Item 2683"/>
+        <handlers:Item Key="item0A7C" Value="Item 2684"/>
+        <handlers:Item Key="item0A7D" Value="Item 2685"/>
+        <handlers:Item Key="item0A7E" Value="銅の錬金チケット"/>
+        <handlers:Item Key="item0A7F" Value="銀の錬金チケット"/>
+        <handlers:Item Key="item0A80" Value="Steel Melding Feystone"/>
+        <handlers:Item Key="item0A81" Value="Silver Melding Feystone"/>
+        <handlers:Item Key="item0A82" Value="金の錬金チケット"/>
+        <handlers:Item Key="item0A83" Value="天の錬金チケット"/>
+        <handlers:Item Key="item0A84" Value="Gold Melding Feystone"/>
+        <handlers:Item Key="item0A85" Value="Astral Melding Feystone"/>
+        <handlers:Item Key="item0A86" Value="Item 2694"/>
+        <handlers:Item Key="item0A87" Value="Item 2695"/>
+        <handlers:Item Key="item0A88" Value="Item 2696"/>
+        <handlers:Item Key="item0A89" Value="Item 2697"/>
+        <handlers:Item Key="item0A8A" Value="Item 2698"/>
+        <handlers:Item Key="item0A8B" Value="Item 2699"/>
+        <handlers:Item Key="item0A8C" Value="Item 2700"/>
+        <handlers:Item Key="item0A8D" Value="Item 2701"/>
+        <handlers:Item Key="item0A8E" Value="Item 2702"/>
+        <handlers:Item Key="item0A8F" Value="Item 2703"/>
+        <handlers:Item Key="item0A90" Value="Item 2704"/>
+        <handlers:Item Key="item0A91" Value="Item 2705"/>
+        <handlers:Item Key="item0A92" Value="Item 2706"/>
+        <handlers:Item Key="item0A93" Value="Item 2707"/>
+        <handlers:Item Key="item0A94" Value="Item 2708"/>
+        <handlers:Item Key="item0A95" Value="Item 2709"/>
+        <handlers:Item Key="item0A96" Value="万福チケット"/>
+        <handlers:Item Key="item0A97" Value="ペンギンチケット"/>
+        <handlers:Item Key="item0A98" Value="封印の龍骸布"/>
+        <handlers:Item Key="item0A99" Value="マッスルチケット"/>
+        <handlers:Item Key="item0A9A" Value="ピッケルチケット"/>
+        <handlers:Item Key="item0A9B" Value="大感謝チケット"/>
+        <handlers:Item Key="item0A9C" Value="竜人族チケット"/>
+        <handlers:Item Key="item0A9D" Value="祭典チケット"/>
+        <handlers:Item Key="item0A9E" Value="食事場チケット【肉】"/>
+        <handlers:Item Key="item0A9F" Value="Item 2719"/>
+        <handlers:Item Key="item0AA0" Value="Item 2720"/>
+        <handlers:Item Key="item0AA1" Value="Item 2721"/>
+        <handlers:Item Key="item0AA2" Value="Item 2722"/>
+        <handlers:Item Key="item0AA3" Value="Item 2723"/>
+        <handlers:Item Key="item0AA4" Value="Item 2724"/>
+        <handlers:Item Key="item0AA5" Value="Item 2725"/>
+        <handlers:Item Key="item0AA6" Value="Item 2726"/>
+        <handlers:Item Key="item0AA7" Value="Item 2727"/>
+        <handlers:Item Key="item0AA8" Value="Item 2728"/>
+        <handlers:Item Key="item0AA9" Value="Item 2729"/>
+        <handlers:Item Key="item0AAA" Value="親友の証"/>
+        <handlers:Item Key="item0AAB" Value="Item 2731"/>
+        <handlers:Item Key="item0AAC" Value="Item 2732"/>
+        <handlers:Item Key="item0AAD" Value="Item 2733"/>
+        <handlers:Item Key="item0AAE" Value="Item 2734"/>
+        <handlers:Item Key="item0AAF" Value="万福チケットSP"/>
+        <handlers:Item Key="item0AB0" Value="大感謝チケットSP"/>
+    </x:Array>
+
+</ResourceDictionary>


### PR DESCRIPTION
An item list for IceIceborne.
The Japanese version of MHW old was created at the following URL.
All you have to do is translate the name to Iceborne.

Source URL: https://github.com/KeisukeOkaya/MHW-Shop-Editor/blob/master/MHW-Shop-Editor/Lang.ja-JP.xaml